### PR TITLE
Exploration: Add Mapterhorn elevation panel and hillshade overlay

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -36,12 +36,22 @@ jobs:
         run: cat pr_metadata/pr_metadata.ini >> $GITHUB_OUTPUT
 
       - name: Deploy to Netlify
+        id: netlify_deploy
         env:
           NETLIFY_AUTH_TOKEN: ${{secrets.NETLIFY_AUTH_TOKEN}}
           NETLIFY_SITE_ID: ${{secrets.NETLIFY_SITE_ID}}
-        run: npx netlify-cli deploy --no-build --dir=. --alias=pr-${{steps.pr_metadata.outputs.pr}}
+        run: |
+          if [ -z "$NETLIFY_AUTH_TOKEN" ] || [ -z "$NETLIFY_SITE_ID" ]; then
+            echo "Skipping Actions Netlify deploy: NETLIFY_AUTH_TOKEN / NETLIFY_SITE_ID not configured."
+            echo "Rely on the Netlify GitHub App deploy-preview check instead."
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          npx netlify-cli deploy --no-build --dir=. --alias=pr-${{steps.pr_metadata.outputs.pr}}
+          echo "skipped=false" >> "$GITHUB_OUTPUT"
 
       - name: Run afterDeploy script
+        if: ${{steps.netlify_deploy.outputs.skipped != 'true'}}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |

--- a/API.md
+++ b/API.md
@@ -42,6 +42,8 @@ of iD (e.g. `https://ideditor-release.netlify.app`), the following parameters ar
   _Example:_ `notes=true`
 * __`offset`__ - Background imagery alignment offset in meters, formatted as `east,north`.<br/>
   _Example:_ `offset=-10,5`
+* __`overlays`__ - Comma-separated list of overlay imagery layer `id` values from iD's imagery list. Multiple overlays can be active at once.<br/>
+  _Example:_ `overlays=mapterhorn-hillshade,openrailwaymap-maxspeeds`
 * __`photo_overlay`__ - The street-level photo overlay layers to enable.<br/>
   _Example:_ `photo_overlay=streetside,mapillary,kartaview`<br/>
   _Available values:_ `streetside` (Microsoft Bing), `mapillary`, `mapillary-signs`, `mapillary-map-features`, `kartaview`

--- a/css/20_map.css
+++ b/css/20_map.css
@@ -365,6 +365,12 @@ g.auxiliary path.preview {
     stroke-width: 2;
     stroke-dasharray: 8, 4;
 }
+g.auxiliary circle.elevation-hover-marker {
+    fill: #7092ff;
+    stroke: #fff;
+    stroke-width: 2;
+    pointer-events: none;
+}
 
 /* Visual Diffs
 ------------------

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -4718,9 +4718,8 @@ img.tile-debug {
     pointer-events: auto;
 }
 
-.panel-container .elevation-layer-toggle {
-    margin: 0 10px 8px;
-    width: calc(100% - 20px);
+.panel-container .elevation-overlay-toggle {
+    margin: 0 -10px 4px;
 }
 .panel-content-elevation .elevation-hint,
 .panel-content-elevation .elevation-loading,
@@ -4729,13 +4728,24 @@ img.tile-debug {
     color: #ccc;
     font-size: 12px;
 }
+.panel-content-elevation .elevation-chart-wrap {
+    position: relative;
+    margin: 0 -10px 4px;
+    width: calc(100% + 20px);
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    box-sizing: border-box;
+}
 .panel-content-elevation .elevation-current {
-    padding: 0 10px 6px;
+    position: absolute;
+    left: 8px;
+    bottom: 4px;
+    z-index: 1;
     font-size: 12px;
     color: #ff8;
+    pointer-events: none;
 }
-.panel-content-elevation .elevation-chart-wrap {
-    padding: 0 6px 4px;
+.panel-content-elevation .elevation-chart {
+    display: block;
 }
 .panel-content-elevation .elevation-chart-line {
     stroke: #8cf;

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -4568,6 +4568,17 @@ img.tile-debug {
 .layer-overlay {
     z-index: 2;
 }
+.layer-overlay-hillshade {
+    opacity: 0.55;
+    mix-blend-mode: multiply;
+    pointer-events: none;
+}
+.layer-overlay-hillshade canvas.tile {
+    position: absolute;
+    transform-origin: 0 0;
+    user-select: none;
+    pointer-events: none;
+}
 .layer-data {
     z-index: 3;
 }
@@ -4705,6 +4716,45 @@ img.tile-debug {
     width: 250px;
     max-width: 100%;
     pointer-events: auto;
+}
+
+.panel-container .elevation-layer-toggle {
+    margin: 0 10px 8px;
+    width: calc(100% - 20px);
+}
+.panel-content-elevation .elevation-hint,
+.panel-content-elevation .elevation-loading,
+.panel-content-elevation .elevation-chart-empty {
+    padding: 0 10px 8px;
+    color: #ccc;
+    font-size: 12px;
+}
+.panel-content-elevation .elevation-current {
+    padding: 0 10px 6px;
+    font-size: 12px;
+    color: #ff8;
+}
+.panel-content-elevation .elevation-chart-wrap {
+    padding: 0 6px 4px;
+}
+.panel-content-elevation .elevation-chart-line {
+    stroke: #8cf;
+    stroke-width: 1.5;
+}
+.panel-content-elevation .elevation-chart-cursor {
+    fill: #7092ff;
+    stroke: #fff;
+    stroke-width: 1.5;
+}
+.panel-content-elevation .elevation-chart-crosshair {
+    stroke: #7092ff;
+    stroke-width: 1;
+    stroke-dasharray: 3, 3;
+    opacity: 0.8;
+}
+.panel-content-elevation .elevation-chart-label {
+    fill: #aaa;
+    font-size: 10px;
 }
 
 .panel-container .panel-title {

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -675,8 +675,6 @@ en:
     elevation:
       key: E
       title: Elevation
-      show_layer: Show Layer
-      hide_layer: Hide Layer
       select_way: Select a single line to see its elevation profile.
       loading: Loading elevation profile…
       no_data: Not enough elevation data for this way.

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -672,6 +672,15 @@ en:
       key: L
       title: Location
       unknown_location: Unknown Location
+    elevation:
+      key: E
+      title: Elevation
+      show_layer: Show Layer
+      hide_layer: Hide Layer
+      select_way: Select a single line to see its elevation profile.
+      loading: Loading elevation profile…
+      no_data: Not enough elevation data for this way.
+      at_point: "Elevation: {elevation} m"
     measurement:
       key: M
       title: Measurement
@@ -846,6 +855,9 @@ en:
     location_panel:
       description: Show Location Panel
       tooltip: Show coordinates and regional details.
+    elevation_panel:
+      description: Show Elevation Panel
+      tooltip: Show elevation profile for the selected way using Mapterhorn tiles.
     fix_misalignment: Imagery Offset
     offset: "Drag anywhere in the gray area below to adjust the imagery offset, or enter the offset values in meters."
     offset_label: "Adjust Imagery Offset"

--- a/data/imagery.json
+++ b/data/imagery.json
@@ -143605,6 +143605,20 @@
     "icon": "https://osmlab.github.io/editor-layer-index/sources/world/MapBoxSatellite.png"
   },
   {
+    "id": "mapterhorn-hillshade",
+    "name": "Mapterhorn Hillshade",
+    "type": "dem",
+    "template": "https://tiles.mapterhorn.com/{z}/{x}/{y}.webp",
+    "category": "elevation",
+    "zoomExtent": [0, 15],
+    "terms_url": "https://mapterhorn.com/attribution",
+    "terms_text": "Mapterhorn",
+    "description": "Global terrain hillshade derived from Mapterhorn elevation tiles.",
+    "encoding": "terrarium",
+    "overlay": true,
+    "tileSize": 512
+  },
+  {
     "id": "Marion_Ortho_2023",
     "name": "Marion County Orthoimagery (2023)",
     "type": "wms",

--- a/data/manual_imagery.json
+++ b/data/manual_imagery.json
@@ -42,5 +42,26 @@
         },
         "url": "7586487389962e3f7c24b076dcc8270e6e23a5cb81e890c3fbe9928c5093fa862d8d946ea4a44f02efec19eda9f69b0bc82df4d53b740a5e284aef977eda72de707e354b5b2aa6f1afe22e7c67af90bcb2f8b411c773f6975badf128356ed1bc36fab11bb8fb221958273b22615127e25f52d3b423676a0ae92e2c9293321614e93443ce3b4fd688e8d58f0e9024a515beb7c68a31231802580a3c6507cdc9cb2195380de5bb857dc3049e9fa74be47bbdc78f4e16a08b08c231a2deae3d45c6548bbbf48154d971eb400bc0957f9b48cb9c4d6501",
         "encrypted": true
+    },
+    {
+        "id": "mapterhorn-hillshade",
+        "name": "Mapterhorn Hillshade",
+        "type": "dem",
+        "category": "elevation",
+        "overlay": true,
+        "tileSize": 512,
+        "encoding": "terrarium",
+        "url": "https://tiles.mapterhorn.com/{z}/{x}/{y}.webp",
+        "attribution": {
+            "text": "Mapterhorn",
+            "url": "https://mapterhorn.com/attribution",
+            "required": true
+        },
+        "permission_osm": "explicit",
+        "description": "Global terrain hillshade derived from Mapterhorn elevation tiles.",
+        "extent": {
+            "min_zoom": 0,
+            "max_zoom": 15
+        }
     }
 ]

--- a/modules/core/context.js
+++ b/modules/core/context.js
@@ -17,6 +17,7 @@ import { geoRawMercator } from '../geo/raw_mercator';
 import { modeSelect, modeSelectNote } from '../modes';
 import { presetManager } from '../presets';
 import { rendererBackground, rendererFeatures, rendererMap, rendererPhotos } from '../renderer';
+import { elevationManager } from '../elevation';
 import { services } from '../services';
 import { uiInit } from '../ui/init';
 import { utilKeybinding, utilRebind, utilStringQs, utilCleanOsmString } from '../util';
@@ -386,6 +387,12 @@ export function coreContext() {
   context.background = () => _background;
 
 
+  /* Elevation */
+  /** @type {ReturnType<elevationManager>} */
+  let _elevation;
+  context.elevation = () => _elevation;
+
+
   /* Features */
   /** @type {ReturnType<rendererFeatures>} */
   let _features;
@@ -579,6 +586,7 @@ export function coreContext() {
       _uploader = coreUploader(context);
 
       _background = rendererBackground(context);
+      _elevation = elevationManager(context);
       _features = rendererFeatures(context);
       _map = rendererMap(context);
       _photos = rendererPhotos(context);

--- a/modules/elevation/constants.ts
+++ b/modules/elevation/constants.ts
@@ -1,0 +1,11 @@
+export const MAPTERHORN_OVERLAY_ID = 'mapterhorn-hillshade';
+
+export const MAPTERHORN_TILE_TEMPLATE = 'https://tiles.mapterhorn.com/{z}/{x}/{y}.webp';
+
+export const MAPTERHORN_TILE_SIZE = 512;
+
+export const MAPTERHORN_ZOOM_EXTENT: [number, number] = [0, 15];
+
+export const PROFILE_SAMPLE_STEP_METERS = 15;
+
+export const PROFILE_TILE_ZOOM = 14;

--- a/modules/elevation/geometry.ts
+++ b/modules/elevation/geometry.ts
@@ -1,9 +1,39 @@
-import { geoSphericalDistance } from '../geo';
+import { geoLatToMeters, geoLonToMeters, geoMetersToLat, geoMetersToLon, geoSphericalDistance } from '../geo';
 
 export interface ClosestLineResult {
   loc: [number, number];
   distanceAlong: number;
   distanceToLine: number;
+}
+
+function closestPointOnSegment(
+  a: [number, number],
+  b: [number, number],
+  loc: [number, number]
+): { loc: [number, number]; t: number; dist: number } {
+  const midLat = (a[1] + b[1] + loc[1]) / 3;
+  const ax = geoLonToMeters(a[0], midLat);
+  const ay = geoLatToMeters(a[1]);
+  const bx = geoLonToMeters(b[0], midLat);
+  const by = geoLatToMeters(b[1]);
+  const px = geoLonToMeters(loc[0], midLat);
+  const py = geoLatToMeters(loc[1]);
+
+  const dx = bx - ax;
+  const dy = by - ay;
+  const lenSq = dx * dx + dy * dy;
+  let t = lenSq > 0 ? ((px - ax) * dx + (py - ay) * dy) / lenSq : 0;
+  t = Math.max(0, Math.min(1, t));
+
+  const cx = ax + t * dx;
+  const cy = ay + t * dy;
+  const dist = Math.sqrt((px - cx) ** 2 + (py - cy) ** 2);
+
+  return {
+    loc: [geoMetersToLon(cx, midLat), geoMetersToLat(cy)],
+    t,
+    dist
+  };
 }
 
 /** Find the closest point on a polyline to `loc`, in meters. */
@@ -24,27 +54,11 @@ export function closestPointOnLine(
     const segLen = geoSphericalDistance(a, b);
     if (segLen <= 0) continue;
 
-    let t = 0;
-    let minSegDist = Infinity;
+    const { loc: segLoc, t, dist } = closestPointOnSegment(a, b, loc);
 
-    // coarse search along segment
-    const steps = Math.max(4, Math.ceil(segLen / 5));
-    for (let s = 0; s <= steps; s++) {
-      const ratio = s / steps;
-      const candidate: [number, number] = [
-        a[0] + (b[0] - a[0]) * ratio,
-        a[1] + (b[1] - a[1]) * ratio
-      ];
-      const d = geoSphericalDistance(candidate, loc);
-      if (d < minSegDist) {
-        minSegDist = d;
-        t = ratio;
-      }
-    }
-
-    if (minSegDist < bestDist) {
-      bestDist = minSegDist;
-      bestLoc = [a[0] + (b[0] - a[0]) * t, a[1] + (b[1] - a[1]) * t];
+    if (dist < bestDist) {
+      bestDist = dist;
+      bestLoc = segLoc;
       bestAlong = total + segLen * t;
     }
 

--- a/modules/elevation/geometry.ts
+++ b/modules/elevation/geometry.ts
@@ -1,0 +1,59 @@
+import { geoSphericalDistance } from '../geo';
+
+export interface ClosestLineResult {
+  loc: [number, number];
+  distanceAlong: number;
+  distanceToLine: number;
+}
+
+/** Find the closest point on a polyline to `loc`, in meters. */
+export function closestPointOnLine(
+  coordinates: [number, number][],
+  loc: [number, number]
+): ClosestLineResult | null {
+  if (coordinates.length < 2) return null;
+
+  let bestDist = Infinity;
+  let bestLoc: [number, number] = coordinates[0];
+  let bestAlong = 0;
+  let total = 0;
+
+  for (let i = 1; i < coordinates.length; i++) {
+    const a = coordinates[i - 1];
+    const b = coordinates[i];
+    const segLen = geoSphericalDistance(a, b);
+    if (segLen <= 0) continue;
+
+    let t = 0;
+    let minSegDist = Infinity;
+
+    // coarse search along segment
+    const steps = Math.max(4, Math.ceil(segLen / 5));
+    for (let s = 0; s <= steps; s++) {
+      const ratio = s / steps;
+      const candidate: [number, number] = [
+        a[0] + (b[0] - a[0]) * ratio,
+        a[1] + (b[1] - a[1]) * ratio
+      ];
+      const d = geoSphericalDistance(candidate, loc);
+      if (d < minSegDist) {
+        minSegDist = d;
+        t = ratio;
+      }
+    }
+
+    if (minSegDist < bestDist) {
+      bestDist = minSegDist;
+      bestLoc = [a[0] + (b[0] - a[0]) * t, a[1] + (b[1] - a[1]) * t];
+      bestAlong = total + segLen * t;
+    }
+
+    total += segLen;
+  }
+
+  return {
+    loc: bestLoc,
+    distanceAlong: bestAlong,
+    distanceToLine: bestDist
+  };
+}

--- a/modules/elevation/hillshade.ts
+++ b/modules/elevation/hillshade.ts
@@ -1,0 +1,45 @@
+import { terrariumToElevation } from './terrarium';
+
+/** Build a hillshade RGBA image from Terrarium tile pixels. */
+export function hillshadeFromTerrarium(
+  data: Uint8ClampedArray,
+  width: number,
+  height: number,
+  azimuthDeg = 315,
+  altitudeDeg = 45
+): Uint8ClampedArray {
+  const elevations = new Float32Array(width * height);
+  for (let i = 0; i < width * height; i++) {
+    const o = i * 4;
+    elevations[i] = terrariumToElevation(data[o], data[o + 1], data[o + 2]);
+  }
+
+  const zenith = (90 - altitudeDeg) * Math.PI / 180;
+  const azimuth = azimuthDeg * Math.PI / 180;
+  const output = new Uint8ClampedArray(width * height * 4);
+
+  for (let y = 1; y < height - 1; y++) {
+    for (let x = 1; x < width - 1; x++) {
+      const idx = y * width + x;
+      const dzdx = (elevations[idx + 1] - elevations[idx - 1]) / 2;
+      const dzdy = (elevations[idx + width] - elevations[idx - width]) / 2;
+      const slope = Math.atan(Math.sqrt(dzdx * dzdx + dzdy * dzdy));
+      let aspect = Math.atan2(dzdy, -dzdx);
+      if (aspect < 0) aspect += 2 * Math.PI;
+
+      let shade = 255 * (
+        Math.cos(zenith) * Math.cos(slope) +
+        Math.sin(zenith) * Math.sin(slope) * Math.cos(azimuth - aspect)
+      );
+      shade = Math.max(0, Math.min(255, shade));
+
+      const o = idx * 4;
+      output[o] = shade;
+      output[o + 1] = shade;
+      output[o + 2] = shade;
+      output[o + 3] = 200;
+    }
+  }
+
+  return output;
+}

--- a/modules/elevation/index.ts
+++ b/modules/elevation/index.ts
@@ -1,0 +1,8 @@
+export { MAPTERHORN_OVERLAY_ID, MAPTERHORN_TILE_TEMPLATE, MAPTERHORN_TILE_SIZE, MAPTERHORN_ZOOM_EXTENT } from './constants';
+export { terrariumToElevation, elevationAtTileCoord } from './terrarium';
+export { DemTileCache } from './tile_cache';
+export { buildElevationProfile, densifyLine, closestProfilePoint, profilePointAtDistance } from './profile';
+export type { ProfilePoint } from './profile';
+export { hillshadeFromTerrarium } from './hillshade';
+export { elevationManager } from './manager';
+export type { ElevationManager, ElevationHover } from './manager';

--- a/modules/elevation/manager.ts
+++ b/modules/elevation/manager.ts
@@ -1,0 +1,124 @@
+import { dispatch as d3_dispatch } from 'd3-dispatch';
+
+import {
+  MAPTERHORN_OVERLAY_ID,
+  MAPTERHORN_TILE_SIZE,
+  MAPTERHORN_TILE_TEMPLATE
+} from './constants';
+import { DemTileCache } from './tile_cache';
+import type { ProfilePoint } from './profile';
+
+export interface ElevationHover {
+  loc: [number, number];
+  distance: number;
+  elevation: number | null;
+}
+
+export function elevationManager(context: iD.Context) {
+  const dispatch = d3_dispatch('change', 'hover', 'profile');
+  const cache = new DemTileCache();
+
+  let _profile: ProfilePoint[] = [];
+  let _profileWayId: EntityID | null = null;
+  let _profileLoading = false;
+  let _hover: ElevationHover | null = null;
+  let _mapHoverEnabled = false;
+
+  const manager = {
+    tileCache: () => cache,
+    template: () => MAPTERHORN_TILE_TEMPLATE,
+    tileSize: () => MAPTERHORN_TILE_SIZE,
+    overlayId: () => MAPTERHORN_OVERLAY_ID,
+
+    profile: () => _profile,
+    profileWayId: () => _profileWayId,
+    profileLoading: () => _profileLoading,
+    hover: () => _hover,
+
+    showsOverlay: () => {
+      const source = context.background().findSource(MAPTERHORN_OVERLAY_ID);
+      return source ? context.background().showsLayer(source) : false;
+    },
+
+    panelActive: () => {
+      const ui = context.ui() as unknown as { info?: { isActive?: (id: string) => boolean } };
+      return !!(ui.info && ui.info.isActive && ui.info.isActive('elevation'));
+    },
+
+    setMapHoverEnabled: (val: boolean) => {
+      _mapHoverEnabled = val;
+      return manager;
+    },
+
+    mapHoverEnabled: () => _mapHoverEnabled,
+
+    setHover: (hover: ElevationHover | null) => {
+      _hover = hover;
+      dispatch.call('hover', manager, hover);
+      return manager;
+    },
+
+    clearHover: () => manager.setHover(null),
+
+    toggleOverlay: (show?: boolean) => {
+      const source = context.background().findSource(MAPTERHORN_OVERLAY_ID);
+      if (!source) return manager;
+
+      const isOn = context.background().showsLayer(source);
+      const shouldShow = show !== undefined ? show : !isOn;
+
+      if (shouldShow !== isOn) {
+        context.background().toggleOverlayLayer(source);
+        if (shouldShow && !manager.panelActive()) {
+          const ui = context.ui() as unknown as { info: { toggle: (id: string) => void } };
+          ui.info.toggle('elevation');
+        }
+      }
+      return manager;
+    },
+
+    loadProfileForWay: async (wayId: EntityID, options?: { force?: boolean }) => {
+      const entity = context.hasEntity(wayId);
+      if (!entity || entity.geometry(context.graph()) !== 'line') {
+        _profile = [];
+        _profileWayId = null;
+        dispatch.call('profile', manager);
+        return;
+      }
+
+      if (!options?.force && _profileWayId === wayId && _profile.length && !_profileLoading) return;
+
+      _profileWayId = wayId;
+      _profileLoading = true;
+      dispatch.call('profile', manager);
+
+      const coords = entity.nodes.map((nodeId: EntityID) => {
+        const node = context.entity(nodeId);
+        return node.loc as [number, number];
+      });
+
+      const { buildElevationProfile } = await import('./profile');
+      _profile = await buildElevationProfile(
+        coords,
+        MAPTERHORN_TILE_TEMPLATE,
+        MAPTERHORN_TILE_SIZE,
+        cache
+      );
+      _profileLoading = false;
+      dispatch.call('profile', manager);
+    },
+
+    clearProfile: () => {
+      _profile = [];
+      _profileWayId = null;
+      _profileLoading = false;
+      _hover = null;
+      dispatch.call('profile', manager);
+      dispatch.call('hover', manager, null);
+    }
+  };
+
+  return Object.assign(manager, { on: dispatch.on, off: dispatch.on });
+}
+
+export type ElevationManager = ReturnType<typeof elevationManager>;

--- a/modules/elevation/manager.ts
+++ b/modules/elevation/manager.ts
@@ -6,6 +6,7 @@ import {
   MAPTERHORN_TILE_TEMPLATE
 } from './constants';
 import { DemTileCache } from './tile_cache';
+import { buildElevationProfile } from './profile';
 import type { ProfilePoint } from './profile';
 
 export interface ElevationHover {
@@ -16,11 +17,12 @@ export interface ElevationHover {
 
 export function elevationManager(context: iD.Context) {
   const dispatch = d3_dispatch('change', 'hover', 'profile');
-  const cache = new DemTileCache();
+  const cache = new DemTileCache(120);
 
   let _profile: ProfilePoint[] = [];
   let _profileWayId: EntityID | null = null;
   let _profileLoading = false;
+  let _loadGeneration = 0;
   let _hover: ElevationHover | null = null;
   let _mapHoverEnabled = false;
 
@@ -43,6 +45,14 @@ export function elevationManager(context: iD.Context) {
     panelActive: () => {
       const ui = context.ui() as unknown as { info?: { isActive?: (id: string) => boolean } };
       return !!(ui.info && ui.info.isActive && ui.info.isActive('elevation'));
+    },
+
+    ensurePanelOpen: () => {
+      if (!manager.panelActive()) {
+        const ui = context.ui() as unknown as { info: { toggle: (id: string) => void } };
+        ui.info.toggle('elevation');
+      }
+      return manager;
     },
 
     setMapHoverEnabled: (val: boolean) => {
@@ -69,9 +79,8 @@ export function elevationManager(context: iD.Context) {
 
       if (shouldShow !== isOn) {
         context.background().toggleOverlayLayer(source);
-        if (shouldShow && !manager.panelActive()) {
-          const ui = context.ui() as unknown as { info: { toggle: (id: string) => void } };
-          ui.info.toggle('elevation');
+        if (shouldShow) {
+          manager.ensurePanelOpen();
         }
       }
       return manager;
@@ -80,14 +89,17 @@ export function elevationManager(context: iD.Context) {
     loadProfileForWay: async (wayId: EntityID, options?: { force?: boolean }) => {
       const entity = context.hasEntity(wayId);
       if (!entity || entity.geometry(context.graph()) !== 'line') {
+        _loadGeneration++;
         _profile = [];
         _profileWayId = null;
+        _profileLoading = false;
         dispatch.call('profile', manager);
         return;
       }
 
       if (!options?.force && _profileWayId === wayId && _profile.length && !_profileLoading) return;
 
+      const generation = ++_loadGeneration;
       _profileWayId = wayId;
       _profileLoading = true;
       dispatch.call('profile', manager);
@@ -97,18 +109,22 @@ export function elevationManager(context: iD.Context) {
         return node.loc as [number, number];
       });
 
-      const { buildElevationProfile } = await import('./profile');
-      _profile = await buildElevationProfile(
+      const profile = await buildElevationProfile(
         coords,
         MAPTERHORN_TILE_TEMPLATE,
         MAPTERHORN_TILE_SIZE,
         cache
       );
+
+      if (generation !== _loadGeneration) return;
+
+      _profile = profile;
       _profileLoading = false;
       dispatch.call('profile', manager);
     },
 
     clearProfile: () => {
+      _loadGeneration++;
       _profile = [];
       _profileWayId = null;
       _profileLoading = false;

--- a/modules/elevation/manager.ts
+++ b/modules/elevation/manager.ts
@@ -101,7 +101,10 @@ export function elevationManager(context: iD.Context) {
 
       const generation = ++_loadGeneration;
       _profileWayId = wayId;
+      _profile = [];
       _profileLoading = true;
+      _hover = null;
+      dispatch.call('hover', manager, null);
       dispatch.call('profile', manager);
 
       const coords = entity.nodes.map((nodeId: EntityID) => {

--- a/modules/elevation/manager.ts
+++ b/modules/elevation/manager.ts
@@ -109,18 +109,26 @@ export function elevationManager(context: iD.Context) {
         return node.loc as [number, number];
       });
 
-      const profile = await buildElevationProfile(
-        coords,
-        MAPTERHORN_TILE_TEMPLATE,
-        MAPTERHORN_TILE_SIZE,
-        cache
-      );
+      try {
+        const profile = await buildElevationProfile(
+          coords,
+          MAPTERHORN_TILE_TEMPLATE,
+          MAPTERHORN_TILE_SIZE,
+          cache
+        );
 
-      if (generation !== _loadGeneration) return;
+        if (generation !== _loadGeneration) return;
 
-      _profile = profile;
-      _profileLoading = false;
-      dispatch.call('profile', manager);
+        _profile = profile;
+      } catch {
+        if (generation !== _loadGeneration) return;
+        _profile = [];
+      } finally {
+        if (generation === _loadGeneration) {
+          _profileLoading = false;
+          dispatch.call('profile', manager);
+        }
+      }
     },
 
     clearProfile: () => {

--- a/modules/elevation/manager.ts
+++ b/modules/elevation/manager.ts
@@ -8,6 +8,7 @@ import {
 import { DemTileCache } from './tile_cache';
 import { buildElevationProfile } from './profile';
 import type { ProfilePoint } from './profile';
+import { utilRebind } from '../util/rebind';
 
 export interface ElevationHover {
   loc: [number, number];
@@ -149,7 +150,7 @@ export function elevationManager(context: iD.Context) {
     }
   };
 
-  return Object.assign(manager, { on: dispatch.on, off: dispatch.on });
+  return utilRebind(manager, dispatch, 'on');
 }
 
 export type ElevationManager = ReturnType<typeof elevationManager>;

--- a/modules/elevation/manager.ts
+++ b/modules/elevation/manager.ts
@@ -122,12 +122,16 @@ export function elevationManager(context: iD.Context) {
 
         if (generation !== _loadGeneration) return;
 
+        // Generation token already guards against stale completions.
+        // eslint-disable-next-line require-atomic-updates -- guarded by generation check
         _profile = profile;
       } catch {
         if (generation !== _loadGeneration) return;
+        // eslint-disable-next-line require-atomic-updates -- guarded by generation check
         _profile = [];
       } finally {
         if (generation === _loadGeneration) {
+          // eslint-disable-next-line require-atomic-updates -- guarded by generation check
           _profileLoading = false;
           dispatch.call('profile', manager);
         }

--- a/modules/elevation/profile.ts
+++ b/modules/elevation/profile.ts
@@ -1,5 +1,6 @@
 import { geoSphericalDistance } from '../geo';
 import { DemTileCache } from './tile_cache';
+import { elevationAtTileCoord } from './terrarium';
 import { PROFILE_SAMPLE_STEP_METERS, PROFILE_TILE_ZOOM } from './constants';
 
 export interface ProfilePoint {
@@ -43,6 +44,27 @@ export function densifyLine(
   return samples;
 }
 
+interface SampleTileInfo {
+  sample: { loc: [number, number]; distance: number };
+  tileKey: string;
+  fracX: number;
+  fracY: number;
+}
+
+function tileCoordForLoc(
+  lon: number,
+  lat: number,
+  zoom: number
+): { x: number; y: number; fracX: number; fracY: number } {
+  const n = Math.pow(2, zoom);
+  const xf = (lon + 180) / 360 * n;
+  const latRad = lat * Math.PI / 180;
+  const yf = (1 - Math.log(Math.tan(latRad) + 1 / Math.cos(latRad)) / Math.PI) / 2 * n;
+  const x = Math.floor(xf);
+  const y = Math.floor(yf);
+  return { x, y, fracX: xf - x, fracY: yf - y };
+}
+
 export async function buildElevationProfile(
   coordinates: [number, number][],
   template: string,
@@ -51,18 +73,40 @@ export async function buildElevationProfile(
   zoom = PROFILE_TILE_ZOOM
 ): Promise<ProfilePoint[]> {
   const samples = densifyLine(coordinates);
-  const profile: ProfilePoint[] = [];
+  const sampleInfos: SampleTileInfo[] = [];
+  const uniqueTiles = new Map<string, { url: string; z: number; x: number; y: number }>();
 
   for (const sample of samples) {
-    const elevation = await cache.getElevation(sample.loc[0], sample.loc[1], template, zoom, tileSize);
-    profile.push({
+    const { x, y, fracX, fracY } = tileCoordForLoc(sample.loc[0], sample.loc[1], zoom);
+    const tileKey = DemTileCache.key(zoom, x, y);
+
+    sampleInfos.push({ sample, tileKey, fracX, fracY });
+
+    if (!uniqueTiles.has(tileKey)) {
+      const url = template
+        .replace(/\{z\}/g, String(zoom))
+        .replace(/\{x\}/g, String(x))
+        .replace(/\{y\}/g, String(y));
+      uniqueTiles.set(tileKey, { url, z: zoom, x, y });
+    }
+  }
+
+  const tiles = new Map<string, Awaited<ReturnType<DemTileCache['fetch']>>>();
+  await Promise.all([...uniqueTiles.entries()].map(async ([key, coord]) => {
+    tiles.set(key, await cache.fetch(coord.url, coord.z, coord.x, coord.y, tileSize));
+  }));
+
+  return sampleInfos.map(({ sample, tileKey, fracX, fracY }) => {
+    const tile = tiles.get(tileKey);
+    const elevation = tile
+      ? elevationAtTileCoord(tile.data, tile.tileSize, fracX, fracY)
+      : null;
+    return {
       loc: sample.loc,
       distance: sample.distance,
       elevation
-    });
-  }
-
-  return profile;
+    };
+  });
 }
 
 /** Find closest profile point to a map location. */

--- a/modules/elevation/profile.ts
+++ b/modules/elevation/profile.ts
@@ -1,0 +1,111 @@
+import { geoSphericalDistance } from '../geo';
+import { DemTileCache } from './tile_cache';
+import { PROFILE_SAMPLE_STEP_METERS, PROFILE_TILE_ZOOM } from './constants';
+
+export interface ProfilePoint {
+  loc: [number, number];
+  distance: number;
+  elevation: number | null;
+}
+
+function interpolateLoc(a: [number, number], b: [number, number], t: number): [number, number] {
+  return [a[0] + (b[0] - a[0]) * t, a[1] + (b[1] - a[1]) * t];
+}
+
+/** Densify a line into sample points spaced roughly `stepMeters` apart. */
+export function densifyLine(
+  coordinates: [number, number][],
+  stepMeters = PROFILE_SAMPLE_STEP_METERS
+): { loc: [number, number]; distance: number }[] {
+  if (coordinates.length < 2) {
+    return coordinates.map((loc, i) => ({ loc, distance: i === 0 ? 0 : 0 }));
+  }
+
+  const samples: { loc: [number, number]; distance: number }[] = [];
+  let total = 0;
+  samples.push({ loc: coordinates[0], distance: 0 });
+
+  for (let i = 1; i < coordinates.length; i++) {
+    const a = coordinates[i - 1];
+    const b = coordinates[i];
+    const segLen = geoSphericalDistance(a, b);
+    if (segLen <= 0) continue;
+
+    const steps = Math.max(1, Math.ceil(segLen / stepMeters));
+    for (let s = 1; s <= steps; s++) {
+      const t = s / steps;
+      const loc = interpolateLoc(a, b, t);
+      total += segLen / steps;
+      samples.push({ loc, distance: total });
+    }
+  }
+
+  return samples;
+}
+
+export async function buildElevationProfile(
+  coordinates: [number, number][],
+  template: string,
+  tileSize: number,
+  cache: DemTileCache,
+  zoom = PROFILE_TILE_ZOOM
+): Promise<ProfilePoint[]> {
+  const samples = densifyLine(coordinates);
+  const profile: ProfilePoint[] = [];
+
+  for (const sample of samples) {
+    const elevation = await cache.getElevation(sample.loc[0], sample.loc[1], template, zoom, tileSize);
+    profile.push({
+      loc: sample.loc,
+      distance: sample.distance,
+      elevation
+    });
+  }
+
+  return profile;
+}
+
+/** Find closest profile point to a map location. */
+export function closestProfilePoint(
+  profile: ProfilePoint[],
+  loc: [number, number]
+): ProfilePoint | null {
+  if (!profile.length) return null;
+
+  let best = profile[0];
+  let bestDist = geoSphericalDistance(best.loc, loc);
+
+  for (let i = 1; i < profile.length; i++) {
+    const d = geoSphericalDistance(profile[i].loc, loc);
+    if (d < bestDist) {
+      bestDist = d;
+      best = profile[i];
+    }
+  }
+
+  return best;
+}
+
+/** Find profile point nearest to a distance along the line. */
+export function profilePointAtDistance(profile: ProfilePoint[], distance: number): ProfilePoint | null {
+  if (!profile.length) return null;
+  if (distance <= profile[0].distance) return profile[0];
+
+  for (let i = 1; i < profile.length; i++) {
+    if (distance <= profile[i].distance) {
+      const prev = profile[i - 1];
+      const next = profile[i];
+      const span = next.distance - prev.distance;
+      const t = span > 0 ? (distance - prev.distance) / span : 0;
+      return {
+        distance,
+        loc: interpolateLoc(prev.loc, next.loc, t),
+        elevation: prev.elevation !== null && next.elevation !== null
+          ? prev.elevation + (next.elevation - prev.elevation) * t
+          : (prev.elevation ?? next.elevation)
+      };
+    }
+  }
+
+  return profile[profile.length - 1];
+}

--- a/modules/elevation/terrarium.ts
+++ b/modules/elevation/terrarium.ts
@@ -1,0 +1,38 @@
+/** Decode Terrarium-encoded elevation in meters. */
+export function terrariumToElevation(r: number, g: number, b: number): number {
+  return (r * 256 + g + b / 256) - 32768;
+}
+
+/** Decode elevation at pixel offset in RGBA image data. */
+export function elevationAtPixel(data: Uint8ClampedArray, width: number, x: number, y: number): number {
+  const px = Math.max(0, Math.min(width - 1, Math.round(x)));
+  const py = Math.max(0, Math.min(Math.floor(data.length / (width * 4)) - 1, Math.round(y)));
+  const i = (py * width + px) * 4;
+  return terrariumToElevation(data[i], data[i + 1], data[i + 2]);
+}
+
+/** Bilinear interpolation of elevation within a tile. */
+export function elevationAtTileCoord(
+  data: Uint8ClampedArray,
+  tileSize: number,
+  fracX: number,
+  fracY: number
+): number {
+  const x = fracX * (tileSize - 1);
+  const y = fracY * (tileSize - 1);
+  const x0 = Math.floor(x);
+  const y0 = Math.floor(y);
+  const x1 = Math.min(tileSize - 1, x0 + 1);
+  const y1 = Math.min(tileSize - 1, y0 + 1);
+  const tx = x - x0;
+  const ty = y - y0;
+
+  const e00 = elevationAtPixel(data, tileSize, x0, y0);
+  const e10 = elevationAtPixel(data, tileSize, x1, y0);
+  const e01 = elevationAtPixel(data, tileSize, x0, y1);
+  const e11 = elevationAtPixel(data, tileSize, x1, y1);
+
+  const e0 = e00 * (1 - tx) + e10 * tx;
+  const e1 = e01 * (1 - tx) + e11 * tx;
+  return e0 * (1 - ty) + e1 * ty;
+}

--- a/modules/elevation/tile_cache.ts
+++ b/modules/elevation/tile_cache.ts
@@ -32,10 +32,10 @@ export class DemTileCache {
     }
   }
 
-  async fetch(url: string, z: number, x: number, y: number, tileSize: number): Promise<DemTileData | null> {
+  fetch(url: string, z: number, x: number, y: number, tileSize: number): Promise<DemTileData | null> {
     const key = DemTileCache.key(z, x, y);
     const cached = this._cache.get(key);
-    if (cached) return cached;
+    if (cached) return Promise.resolve(cached);
 
     let promise = this._inflight.get(key);
     if (!promise) {

--- a/modules/elevation/tile_cache.ts
+++ b/modules/elevation/tile_cache.ts
@@ -8,7 +8,7 @@ export interface DemTileData {
 }
 
 export class DemTileCache {
-  private _cache = new Map<TileKey, DemTileData | null>();
+  private _cache = new Map<TileKey, DemTileData>();
   private _inflight = new Map<TileKey, Promise<DemTileData | null>>();
   private _maxSize: number;
 
@@ -34,14 +34,18 @@ export class DemTileCache {
 
   async fetch(url: string, z: number, x: number, y: number, tileSize: number): Promise<DemTileData | null> {
     const key = DemTileCache.key(z, x, y);
-    if (this._cache.has(key)) return this._cache.get(key) ?? null;
+    const cached = this._cache.get(key);
+    if (cached) return cached;
 
     let promise = this._inflight.get(key);
     if (!promise) {
       promise = this._load(url, tileSize).then(result => {
         this._inflight.delete(key);
-        this._cache.set(key, result);
-        this._trim();
+        // Only cache successful tiles so transient failures can be retried.
+        if (result) {
+          this._cache.set(key, result);
+          this._trim();
+        }
         return result;
       });
       this._inflight.set(key, promise);

--- a/modules/elevation/tile_cache.ts
+++ b/modules/elevation/tile_cache.ts
@@ -1,0 +1,99 @@
+import { elevationAtTileCoord } from './terrarium';
+
+export type TileKey = string;
+
+export interface DemTileData {
+  data: Uint8ClampedArray;
+  tileSize: number;
+}
+
+export class DemTileCache {
+  private _cache = new Map<TileKey, DemTileData | null>();
+  private _inflight = new Map<TileKey, Promise<DemTileData | null>>();
+  private _maxSize: number;
+
+  constructor(maxSize = 80) {
+    this._maxSize = maxSize;
+  }
+
+  static key(z: number, x: number, y: number): TileKey {
+    return `${z}/${x}/${y}`;
+  }
+
+  clear(): void {
+    this._cache.clear();
+    this._inflight.clear();
+  }
+
+  private _trim(): void {
+    while (this._cache.size > this._maxSize) {
+      const first = this._cache.keys().next().value;
+      if (first !== undefined) this._cache.delete(first);
+    }
+  }
+
+  async fetch(url: string, z: number, x: number, y: number, tileSize: number): Promise<DemTileData | null> {
+    const key = DemTileCache.key(z, x, y);
+    if (this._cache.has(key)) return this._cache.get(key) ?? null;
+
+    let promise = this._inflight.get(key);
+    if (!promise) {
+      promise = this._load(url, tileSize).then(result => {
+        this._inflight.delete(key);
+        this._cache.set(key, result);
+        this._trim();
+        return result;
+      });
+      this._inflight.set(key, promise);
+    }
+    return promise;
+  }
+
+  private async _load(url: string, tileSize: number): Promise<DemTileData | null> {
+    try {
+      const response = await fetch(url);
+      if (!response.ok) return null;
+      const blob = await response.blob();
+      const bitmap = await createImageBitmap(blob);
+      const canvas = document.createElement('canvas');
+      canvas.width = tileSize;
+      canvas.height = tileSize;
+      const ctx = canvas.getContext('2d', { willReadFrequently: true });
+      if (!ctx) return null;
+      ctx.drawImage(bitmap, 0, 0, tileSize, tileSize);
+      bitmap.close();
+      const imageData = ctx.getImageData(0, 0, tileSize, tileSize);
+      return { data: imageData.data, tileSize };
+    } catch {
+      return null;
+    }
+  }
+
+  /** Get elevation at lon/lat using tiles at the given zoom. */
+  async getElevation(
+    lon: number,
+    lat: number,
+    template: string,
+    zoom: number,
+    tileSize: number
+  ): Promise<number | null> {
+    const n = Math.pow(2, zoom);
+    const xf = (lon + 180) / 360 * n;
+    const latRad = lat * Math.PI / 180;
+    const yf = (1 - Math.log(Math.tan(latRad) + 1 / Math.cos(latRad)) / Math.PI) / 2 * n;
+
+    const x = Math.floor(xf);
+    const y = Math.floor(yf);
+    const fracX = xf - x;
+    const fracY = yf - y;
+
+    const url = template
+      .replace(/\{z\}/g, String(zoom))
+      .replace(/\{x\}/g, String(x))
+      .replace(/\{y\}/g, String(y));
+
+    const tile = await this.fetch(url, zoom, x, y, tileSize);
+    if (!tile) return null;
+    return elevationAtTileCoord(tile.data, tile.tileSize, fracX, fracY);
+  }
+}

--- a/modules/globals.d.ts
+++ b/modules/globals.d.ts
@@ -28,7 +28,9 @@ declare global {
   }
 
   declare namespace iD {
-    export type Context = ReturnType<typeof iD.coreContext>;
+    export type Context = ReturnType<typeof iD.coreContext> & {
+      elevation: () => import('./elevation/manager').ElevationManager;
+    };
 
     export type Graph = import('./core/graph').coreGraph;
     export type OsmNode = import('./osm/node').OsmNode;

--- a/modules/renderer/background.js
+++ b/modules/renderer/background.js
@@ -11,6 +11,8 @@ import { fileFetcher } from '../core/file_fetcher';
 import { geoMetersToOffset, geoOffsetToMeters, geoExtent } from '../geo';
 import { rendererBackgroundSource } from './background_source';
 import { rendererTileLayer } from './tile_layer';
+import { rendererHillshadeLayer } from './hillshade_layer';
+import { MAPTERHORN_OVERLAY_ID } from '../elevation/constants';
 import { utilAesDecrypt, utilStringQs } from '../util';
 import { utilRebind } from '../util/rebind';
 import { patchHash } from '../behavior';
@@ -188,8 +190,12 @@ export function rendererBackground(context) {
 
     overlays.enter()
       .insert('div', '.layer-data')
-      .attr('class', 'layer layer-overlay')
       .merge(overlays)
+      .attr('class', d => {
+        const source = d.source && d.source();
+        const extra = source && source.type === 'dem' ? ' layer-overlay-hillshade' : '';
+        return 'layer layer-overlay' + extra;
+      })
       .each((layer, i, nodes) => d3_select(nodes[i]).call(layer));
   }
 
@@ -368,14 +374,25 @@ export function rendererBackground(context) {
       }
     }
 
-    layer = rendererTileLayer(context)
+    layer = d.type === 'dem'
+      ? rendererHillshadeLayer(context)
+      : rendererTileLayer(context);
+
+    layer
       .source(d)
       .projection(context.projection)
-      .dimensions(baseLayer.dimensions()
-    );
+      .dimensions(baseLayer.dimensions());
 
     _overlayLayers.push(layer);
     dispatch.call('change');
+
+    if (d.id === MAPTERHORN_OVERLAY_ID && context.elevation) {
+      const elevation = context.elevation();
+      if (!elevation.panelActive()) {
+        context.ui().info.toggle('elevation');
+      }
+    }
+
     background.updateImagery();
   };
 

--- a/modules/renderer/background.js
+++ b/modules/renderer/background.js
@@ -387,10 +387,7 @@ export function rendererBackground(context) {
     dispatch.call('change');
 
     if (d.id === MAPTERHORN_OVERLAY_ID && context.elevation) {
-      const elevation = context.elevation();
-      if (!elevation.panelActive()) {
-        context.ui().info.toggle('elevation');
-      }
+      context.elevation().ensurePanelOpen();
     }
 
     background.updateImagery();

--- a/modules/renderer/background_source.js
+++ b/modules/renderer/background_source.js
@@ -186,7 +186,7 @@ export function rendererBackgroundSource(data) {
               }
             });
 
-        } else if (source.type === 'tms') {
+        } else if (source.type === 'tms' || source.type === 'dem') {
             result = result
                 .replace('{x}', coord[0])
                 .replace('{y}', coord[1])

--- a/modules/renderer/hillshade_layer.js
+++ b/modules/renderer/hillshade_layer.js
@@ -11,7 +11,11 @@ export function rendererHillshadeLayer(context) {
 
     var _tileSize = 256;
     var _projection;
-    var _cache = {};
+    // url -> ImageData of rendered hillshade (reusable when canvases are recreated)
+    var _rendered = {};
+    // url -> false when tile fetch failed (for parent-tile lookup)
+    var _failed = {};
+    var _inflight = {};
     var _tileOrigin;
     var _zoom;
     var _source;
@@ -33,7 +37,7 @@ export function rendererHillshadeLayer(context) {
     function lookUp(d) {
         for (var up = -1; up > -d[2]; up--) {
             var tile = atZoom(d, up);
-            if (_cache[_source.url(tile)] !== false) {
+            if (_failed[_source.url(tile)] !== true) {
                 return tile;
             }
         }
@@ -58,25 +62,50 @@ export function rendererHillshadeLayer(context) {
         return d;
     }
 
+    function paintCanvas(canvas, imageData) {
+        var ctx = canvas.getContext('2d');
+        if (!ctx || !imageData) return;
+        canvas.width = imageData.width;
+        canvas.height = imageData.height;
+        ctx.putImageData(imageData, 0, 0);
+    }
+
     function renderHillshadeTile(canvas, d) {
-        return tileCache.fetch(d.url, d[2], d[0], d[1], d.tileSize)
+        if (_inflight[d.url]) {
+            return _inflight[d.url].then(function(imageData) {
+                if (imageData && canvas.__data__ && canvas.__data__.url === d.url) {
+                    paintCanvas(canvas, imageData);
+                }
+                return !!imageData;
+            });
+        }
+
+        var promise = tileCache.fetch(d.url, d[2], d[0], d[1], d.tileSize)
             .then(function(tile) {
+                delete _inflight[d.url];
                 if (!tile) {
-                    _cache[d.url] = false;
-                    return false;
+                    _failed[d.url] = true;
+                    return null;
                 }
 
                 var shaded = hillshadeFromTerrarium(tile.data, tile.tileSize, tile.tileSize);
-                var ctx = canvas.getContext('2d');
-                if (!ctx) return false;
-
                 var imageData = new ImageData(shaded, tile.tileSize, tile.tileSize);
-                canvas.width = tile.tileSize;
-                canvas.height = tile.tileSize;
-                ctx.putImageData(imageData, 0, 0);
-                _cache[d.url] = true;
-                return true;
+                _rendered[d.url] = imageData;
+                delete _failed[d.url];
+
+                // Only paint if this canvas is still bound to the same tile URL
+                if (canvas.__data__ && canvas.__data__.url === d.url) {
+                    paintCanvas(canvas, imageData);
+                }
+                return imageData;
+            }, function() {
+                delete _inflight[d.url];
+                _failed[d.url] = true;
+                return null;
             });
+
+        _inflight[d.url] = promise;
+        return promise.then(function(imageData) { return !!imageData; });
     }
 
     function background(selection) {
@@ -119,13 +148,13 @@ export function rendererHillshadeLayer(context) {
                 if (d.url === '') return;
                 if (typeof d.url !== 'string') return;
                 requests.push(d);
-                if (_cache[d.url] === false && lookUp(d)) {
+                if (_failed[d.url] && lookUp(d)) {
                     requests.push(addSource(lookUp(d)));
                 }
             });
 
             requests = uniqueBy(requests, 'url').filter(function(r) {
-                return _cache[r.url] !== false;
+                return !_failed[r.url] || _rendered[r.url];
             });
         }
 
@@ -163,8 +192,14 @@ export function rendererHillshadeLayer(context) {
             .classed('tile-removing', false)
             .sort(function(a, b) { return a[2] - b[2]; })
             .each(function(d) {
-                if (_cache[d.url] === true) return;
                 var canvasEl = this;
+                // Reuse rendered ImageData when canvases are recreated after pan
+                if (_rendered[d.url]) {
+                    paintCanvas(canvasEl, _rendered[d.url]);
+                    return;
+                }
+                if (_failed[d.url]) return;
+
                 renderHillshadeTile(canvasEl, d).then(function(painted) {
                     if (painted === false) {
                         render(selection);
@@ -189,7 +224,9 @@ export function rendererHillshadeLayer(context) {
         if (!arguments.length) return _source;
         _source = val;
         _tileSize = _source.tileSize;
-        _cache = {};
+        _rendered = {};
+        _failed = {};
+        _inflight = {};
         tiler.tileSize(_source.tileSize).zoomExtent(_source.zoomExtent);
         return background;
     };

--- a/modules/renderer/hillshade_layer.js
+++ b/modules/renderer/hillshade_layer.js
@@ -1,0 +1,201 @@
+import { select as d3_select } from 'd3-selection';
+
+import { geoScaleToZoom } from '../geo';
+import { utilPrefixCSSProperty, utilTiler } from '../util';
+import { hillshadeFromTerrarium } from '../elevation/hillshade';
+import { DemTileCache } from '../elevation/tile_cache';
+
+export function rendererHillshadeLayer(context) {
+    var transformProp = utilPrefixCSSProperty('Transform');
+    var tiler = utilTiler();
+    var tileCache = new DemTileCache(120);
+
+    var _tileSize = 256;
+    var _projection;
+    var _cache = {};
+    var _tileOrigin;
+    var _zoom;
+    var _source;
+    var _underzoom = 0;
+
+    function tileSizeAtZoom(d, z) {
+        return (d.tileSize * Math.pow(2, z - d[2])) / d.tileSize;
+    }
+
+    function atZoom(t, distance) {
+        var power = Math.pow(2, distance);
+        return [
+            Math.floor(t[0] * power),
+            Math.floor(t[1] * power),
+            t[2] + distance
+        ];
+    }
+
+    function lookUp(d) {
+        for (var up = -1; up > -d[2]; up--) {
+            var tile = atZoom(d, up);
+            if (_cache[_source.url(tile)] !== false) {
+                return tile;
+            }
+        }
+    }
+
+    function uniqueBy(a, n) {
+        var o = [];
+        var seen = {};
+        for (var i = 0; i < a.length; i++) {
+            if (seen[a[i][n]] === undefined) {
+                o.push(a[i]);
+                seen[a[i][n]] = true;
+            }
+        }
+        return o;
+    }
+
+    function addSource(d) {
+        d.url = _source.url(d);
+        d.tileSize = _tileSize;
+        d.source = _source;
+        return d;
+    }
+
+    function renderHillshadeTile(canvas, d) {
+        return tileCache.fetch(d.url, d[2], d[0], d[1], d.tileSize)
+            .then(function(tile) {
+                if (!tile) {
+                    _cache[d.url] = false;
+                    return;
+                }
+
+                var shaded = hillshadeFromTerrarium(tile.data, tile.tileSize, tile.tileSize);
+                var ctx = canvas.getContext('2d');
+                if (!ctx) return;
+
+                var imageData = new ImageData(shaded, tile.tileSize, tile.tileSize);
+                canvas.width = tile.tileSize;
+                canvas.height = tile.tileSize;
+                ctx.putImageData(imageData, 0, 0);
+                _cache[d.url] = true;
+            });
+    }
+
+    function background(selection) {
+        _zoom = geoScaleToZoom(_projection.scale(), _tileSize);
+
+        var pixelOffset;
+        if (_source) {
+            pixelOffset = [
+                _source.offset()[0] * Math.pow(2, _zoom),
+                _source.offset()[1] * Math.pow(2, _zoom)
+            ];
+        } else {
+            pixelOffset = [0, 0];
+        }
+
+        tiler
+            .scale(_projection.scale() * 2 * Math.PI)
+            .translate([
+                _projection.translate()[0] + pixelOffset[0],
+                _projection.translate()[1] + pixelOffset[1]
+            ]);
+
+        _tileOrigin = [
+            _projection.scale() * Math.PI - _projection.translate()[0],
+            _projection.scale() * Math.PI - _projection.translate()[1]
+        ];
+
+        render(selection);
+    }
+
+    function render(selection) {
+        if (!_source) return;
+        var requests = [];
+
+        if (_source.validZoom(_zoom, _underzoom)) {
+            tiler.skipNullIsland(!!_source.overlay);
+
+            tiler().forEach(function(d) {
+                addSource(d);
+                if (d.url === '') return;
+                if (typeof d.url !== 'string') return;
+                requests.push(d);
+                if (_cache[d.url] === false && lookUp(d)) {
+                    requests.push(addSource(lookUp(d)));
+                }
+            });
+
+            requests = uniqueBy(requests, 'url').filter(function(r) {
+                return _cache[r.url] !== false;
+            });
+        }
+
+        function imageTransform(d) {
+            var ts = d.tileSize * Math.pow(2, _zoom - d[2]);
+            var scale = tileSizeAtZoom(d, _zoom);
+            return 'translate(' +
+                ((d[0] * ts + d.source.offset()[0] * Math.pow(2, _zoom)) * _tileSize / d.tileSize - _tileOrigin[0]
+            ) + 'px,' +
+                ((d[1] * ts + d.source.offset()[1] * Math.pow(2, _zoom)) * _tileSize / d.tileSize - _tileOrigin[1]
+            ) + 'px) ' +
+                'scale(' + scale * _tileSize / d.tileSize + ',' + scale * _tileSize / d.tileSize + ')';
+        }
+
+        var canvas = selection.selectAll('canvas')
+            .data(requests, function(d) { return d.url; });
+
+        canvas.exit()
+            .style(transformProp, imageTransform)
+            .classed('tile-removing', true)
+            .on('transitionend', function() {
+                var el = d3_select(this);
+                if (el.classed('tile-removing')) {
+                    el.remove();
+                }
+            });
+
+        canvas.enter()
+            .append('canvas')
+            .attr('class', 'tile tile-hillshade')
+            .style('width', _tileSize + 'px')
+            .style('height', _tileSize + 'px')
+          .merge(canvas)
+            .style(transformProp, imageTransform)
+            .classed('tile-removing', false)
+            .sort(function(a, b) { return a[2] - b[2]; })
+            .each(function(d) {
+                if (_cache[d.url] === true) return;
+                renderHillshadeTile(this, d).then(function() {
+                    render(selection);
+                });
+            });
+    }
+
+    background.projection = function(val) {
+        if (!arguments.length) return _projection;
+        _projection = val;
+        return background;
+    };
+
+    background.dimensions = function(val) {
+        if (!arguments.length) return tiler.size();
+        tiler.size(val);
+        return background;
+    };
+
+    background.source = function(val) {
+        if (!arguments.length) return _source;
+        _source = val;
+        _tileSize = _source.tileSize;
+        _cache = {};
+        tiler.tileSize(_source.tileSize).zoomExtent(_source.zoomExtent);
+        return background;
+    };
+
+    background.underzoom = function(amount) {
+        if (!arguments.length) return _underzoom;
+        _underzoom = amount;
+        return background;
+    };
+
+    return background;
+}

--- a/modules/renderer/hillshade_layer.js
+++ b/modules/renderer/hillshade_layer.js
@@ -3,12 +3,11 @@ import { select as d3_select } from 'd3-selection';
 import { geoScaleToZoom } from '../geo';
 import { utilPrefixCSSProperty, utilTiler } from '../util';
 import { hillshadeFromTerrarium } from '../elevation/hillshade';
-import { DemTileCache } from '../elevation/tile_cache';
 
 export function rendererHillshadeLayer(context) {
     var transformProp = utilPrefixCSSProperty('Transform');
     var tiler = utilTiler();
-    var tileCache = new DemTileCache(120);
+    var tileCache = context.elevation().tileCache();
 
     var _tileSize = 256;
     var _projection;
@@ -64,18 +63,19 @@ export function rendererHillshadeLayer(context) {
             .then(function(tile) {
                 if (!tile) {
                     _cache[d.url] = false;
-                    return;
+                    return false;
                 }
 
                 var shaded = hillshadeFromTerrarium(tile.data, tile.tileSize, tile.tileSize);
                 var ctx = canvas.getContext('2d');
-                if (!ctx) return;
+                if (!ctx) return false;
 
                 var imageData = new ImageData(shaded, tile.tileSize, tile.tileSize);
                 canvas.width = tile.tileSize;
                 canvas.height = tile.tileSize;
                 ctx.putImageData(imageData, 0, 0);
                 _cache[d.url] = true;
+                return true;
             });
     }
 
@@ -164,8 +164,11 @@ export function rendererHillshadeLayer(context) {
             .sort(function(a, b) { return a[2] - b[2]; })
             .each(function(d) {
                 if (_cache[d.url] === true) return;
-                renderHillshadeTile(this, d).then(function() {
-                    render(selection);
+                var canvasEl = this;
+                renderHillshadeTile(canvasEl, d).then(function(painted) {
+                    if (painted === false) {
+                        render(selection);
+                    }
                 });
             });
     }

--- a/modules/renderer/index.js
+++ b/modules/renderer/index.js
@@ -4,3 +4,4 @@ export { rendererFeatures } from './features';
 export { rendererMap } from './map';
 export { rendererPhotos } from './photos';
 export { rendererTileLayer } from './tile_layer';
+export { rendererHillshadeLayer } from './hillshade_layer';

--- a/modules/svg/elevation_auxiliary.ts
+++ b/modules/svg/elevation_auxiliary.ts
@@ -1,5 +1,3 @@
-import { select as d3_select } from 'd3-selection';
-
 export function svgElevationAuxiliary(context: iD.Context) {
   const auxiliary = {
     show(loc: [number, number]) {

--- a/modules/svg/elevation_auxiliary.ts
+++ b/modules/svg/elevation_auxiliary.ts
@@ -1,0 +1,37 @@
+import { select as d3_select } from 'd3-selection';
+
+export function svgElevationAuxiliary(context: iD.Context) {
+  const auxiliary = {
+    show(loc: [number, number]) {
+      const surface = context.surface();
+      const container = surface.selectAll<SVGGElement, unknown>('.data-layer.osm .auxiliary');
+      const projected = context.projection(loc);
+      if (!projected || !isFinite(projected[0]) || !isFinite(projected[1])) {
+        auxiliary.clear();
+        return;
+      }
+
+      const data = [{ id: 'elevation-hover', x: projected[0], y: projected[1] }];
+      const circles = container.selectAll('circle.elevation-hover-marker')
+        .data(data, (d: { id: string }) => d.id);
+
+      circles.exit().remove();
+
+      circles.enter()
+        .append('circle')
+        .attr('class', 'elevation-hover-marker')
+        .merge(circles)
+        .attr('cx', (d: { x: number }) => d.x)
+        .attr('cy', (d: { y: number }) => d.y)
+        .attr('r', 6);
+    },
+
+    clear() {
+      context.surface()
+        .selectAll('.data-layer.osm .auxiliary circle.elevation-hover-marker')
+        .remove();
+    }
+  };
+
+  return auxiliary;
+}

--- a/modules/ui/info.js
+++ b/modules/ui/info.js
@@ -84,6 +84,11 @@ export function uiInfo(context) {
         }
 
 
+        info.isActive = function(which) {
+            return !!active[which];
+        };
+
+
         info.toggle = function(which) {
             var activeids = ids.filter(function(k) { return active[k]; });
 

--- a/modules/ui/panels/elevation.ts
+++ b/modules/ui/panels/elevation.ts
@@ -1,0 +1,284 @@
+import { select as d3_select } from 'd3-selection';
+
+import { t } from '../../core/localizer';
+import { displayLength } from '../../util/units';
+import { localizer } from '../../core/localizer';
+import { closestPointOnLine } from '../../elevation/geometry';
+import { profilePointAtDistance } from '../../elevation/profile';
+import { svgElevationAuxiliary } from '../../svg/elevation_auxiliary';
+
+const CHART_WIDTH = 226;
+const CHART_HEIGHT = 90;
+const CHART_MARGIN = { top: 8, right: 8, bottom: 20, left: 36 };
+
+export function uiPanelElevation(context: iD.Context) {
+  let _isImperial = !localizer.usesMetric();
+  const elevation = context.elevation();
+  const drawAuxiliary = svgElevationAuxiliary(context);
+
+  function selectedWayId(): EntityID | null {
+    const ids = context.selectedIDs().filter((id: EntityID) => context.hasEntity(id));
+    if (ids.length !== 1) return null;
+    const entity = context.entity(ids[0]);
+    return entity.geometry(context.graph()) === 'line' ? ids[0] : null;
+  }
+
+  function drawChart(
+    selection: d3.Selection<any>,
+    profile: import('../../elevation/profile').ProfilePoint[],
+    hoverDistance: number | null
+  ) {
+    selection.selectAll('.elevation-chart').remove();
+
+    const valid = profile.filter(p => p.elevation !== null);
+    if (valid.length < 2) {
+      selection
+        .append('div')
+        .attr('class', 'elevation-chart-empty')
+        .call(t.append('info_panels.elevation.no_data'));
+      return;
+    }
+
+    const distances = valid.map(p => p.distance);
+    const elevations = valid.map(p => p.elevation as number);
+    const minDist = distances[0];
+    const maxDist = distances[distances.length - 1];
+    const minEle = Math.min(...elevations);
+    const maxEle = Math.max(...elevations);
+    const elePad = Math.max(5, (maxEle - minEle) * 0.05);
+    const yMin = minEle - elePad;
+    const yMax = maxEle + elePad;
+
+    const innerW = CHART_WIDTH - CHART_MARGIN.left - CHART_MARGIN.right;
+    const innerH = CHART_HEIGHT - CHART_MARGIN.top - CHART_MARGIN.bottom;
+
+    const xScale = (d: number) => CHART_MARGIN.left + (d - minDist) / (maxDist - minDist || 1) * innerW;
+    const yScale = (e: number) => CHART_MARGIN.top + innerH - (e - yMin) / (yMax - yMin || 1) * innerH;
+
+    const points = valid.map(p => `${xScale(p.distance)},${yScale(p.elevation as number)}`).join(' ');
+
+    const chart = selection
+      .append('svg')
+      .attr('class', 'elevation-chart')
+      .attr('width', CHART_WIDTH)
+      .attr('height', CHART_HEIGHT);
+
+    chart
+      .append('polyline')
+      .attr('class', 'elevation-chart-line')
+      .attr('fill', 'none')
+      .attr('points', points);
+
+    chart
+      .append('rect')
+      .attr('class', 'elevation-chart-hit')
+      .attr('x', CHART_MARGIN.left)
+      .attr('y', CHART_MARGIN.top)
+      .attr('width', innerW)
+      .attr('height', innerH)
+      .attr('fill', 'transparent')
+      .on('pointermove.elevation-chart', function(d3_event) {
+        const rect = (this as SVGRectElement).getBoundingClientRect();
+        const x = d3_event.clientX - rect.left;
+        const ratio = Math.max(0, Math.min(1, (x - CHART_MARGIN.left) / innerW));
+        const distance = minDist + ratio * (maxDist - minDist);
+        const point = profilePointAtDistance(profile, distance);
+        if (point) {
+          elevation.setHover({
+            loc: point.loc,
+            distance: point.distance,
+            elevation: point.elevation
+          });
+        }
+      })
+      .on('pointerleave.elevation-chart', () => {
+        elevation.clearHover();
+      });
+
+    if (hoverDistance !== null) {
+      const hoverPoint = profilePointAtDistance(profile, hoverDistance);
+      if (hoverPoint && hoverPoint.elevation !== null) {
+        chart
+          .append('circle')
+          .attr('class', 'elevation-chart-cursor')
+          .attr('cx', xScale(hoverPoint.distance))
+          .attr('cy', yScale(hoverPoint.elevation))
+          .attr('r', 4);
+
+        chart
+          .append('line')
+          .attr('class', 'elevation-chart-crosshair')
+          .attr('x1', xScale(hoverPoint.distance))
+          .attr('x2', xScale(hoverPoint.distance))
+          .attr('y1', CHART_MARGIN.top)
+          .attr('y2', CHART_MARGIN.top + innerH);
+      }
+    }
+
+    chart
+      .append('text')
+      .attr('class', 'elevation-chart-label')
+      .attr('x', CHART_MARGIN.left)
+      .attr('y', CHART_HEIGHT - 4)
+      .text('0');
+
+    chart
+      .append('text')
+      .attr('class', 'elevation-chart-label')
+      .attr('x', CHART_WIDTH - CHART_MARGIN.right)
+      .attr('y', CHART_HEIGHT - 4)
+      .attr('text-anchor', 'end')
+      .text(displayLength(maxDist, _isImperial));
+  }
+
+  function redraw(selection: d3.Selection<any>) {
+    const wayId = selectedWayId();
+    const profile = elevation.profile();
+    const hover = elevation.hover();
+    const loading = elevation.profileLoading();
+    const overlayOn = elevation.showsOverlay();
+
+    selection.html('');
+
+    const layerToggle = selection
+      .append('button')
+      .attr('class', 'button elevation-layer-toggle')
+      .attr('type', 'button')
+      .text(t(overlayOn ? 'info_panels.elevation.hide_layer' : 'info_panels.elevation.show_layer'))
+      .on('click.elevation-panel', function(d3_event) {
+        d3_event.preventDefault();
+        elevation.toggleOverlay();
+        selection.call(redraw);
+      });
+
+    layerToggle
+      .append('span');
+
+    if (!wayId) {
+      selection
+        .append('div')
+        .attr('class', 'elevation-hint')
+        .call(t.append('info_panels.elevation.select_way'));
+      drawAuxiliary.clear();
+      return;
+    }
+
+    if (loading) {
+      selection
+        .append('div')
+        .attr('class', 'elevation-loading')
+        .call(t.append('info_panels.elevation.loading'));
+      return;
+    }
+
+    if (hover && hover.elevation !== null) {
+      selection
+        .append('div')
+        .attr('class', 'elevation-current')
+        .text(t('info_panels.elevation.at_point', {
+          elevation: Math.round(hover.elevation).toLocaleString(localizer.localeCode())
+        }));
+    }
+
+    const chartContainer = selection
+      .append('div')
+      .attr('class', 'elevation-chart-wrap');
+
+    drawChart(chartContainer, profile, hover?.distance ?? null);
+
+    if (hover) {
+      drawAuxiliary.show(hover.loc);
+    } else {
+      drawAuxiliary.clear();
+    }
+  }
+
+  function refreshProfile() {
+    const wayId = selectedWayId();
+    if (wayId) {
+      elevation.loadProfileForWay(wayId);
+    } else {
+      elevation.clearProfile();
+    }
+  }
+
+  function onMapPointerMove() {
+    if (!elevation.mapHoverEnabled()) return;
+
+    const wayId = selectedWayId();
+    if (!wayId) return;
+
+    const entity = context.entity(wayId);
+    const coords = entity.nodes.map((nodeId: EntityID) => context.entity(nodeId).loc as [number, number]);
+    const loc = context.map().mouseCoordinates() as [number, number];
+    if (!loc || loc.some(isNaN)) return;
+
+    const result = closestPointOnLine(coords, loc);
+    if (!result || result.distanceToLine > 20) {
+      elevation.clearHover();
+      return;
+    }
+
+    const profile = elevation.profile();
+    const point = profilePointAtDistance(profile, result.distanceAlong);
+    if (point) {
+      elevation.setHover({
+        loc: result.loc,
+        distance: point.distance,
+        elevation: point.elevation
+      });
+    }
+  }
+
+  const panel = function(selection: d3.Selection<any>) {
+    elevation.setMapHoverEnabled(true);
+    refreshProfile();
+    selection.call(redraw);
+
+    context.map()
+      .on('drawn.info-elevation', () => selection.call(redraw))
+      .on('move.info-elevation', onMapPointerMove);
+
+    context
+      .on('enter.info-elevation', () => {
+        refreshProfile();
+        selection.call(redraw);
+      });
+
+    context.history()
+      .on('change.info-elevation', () => {
+        const wayId = selectedWayId();
+        if (wayId) {
+          elevation.loadProfileForWay(wayId, { force: true });
+        }
+      });
+
+    context.surface()
+      .on('pointermove.info-elevation', onMapPointerMove);
+
+    elevation.on('profile.info-elevation', () => selection.call(redraw));
+    elevation.on('hover.info-elevation', () => selection.call(redraw));
+
+    context.background()
+      .on('change.info-elevation', () => selection.call(redraw));
+  };
+
+  panel.off = function() {
+    elevation.setMapHoverEnabled(false);
+    elevation.clearHover();
+    drawAuxiliary.clear();
+    context.map().on('drawn.info-elevation', null).on('move.info-elevation', null);
+    context.on('enter.info-elevation', null);
+    context.history().on('change.info-elevation', null);
+    context.surface().on('pointermove.info-elevation', null);
+    elevation.on('profile.info-elevation', null);
+    elevation.on('hover.info-elevation', null);
+    context.background().on('change.info-elevation', null);
+  };
+
+  panel.id = 'elevation';
+  panel.label = t.append('info_panels.elevation.title');
+  panel.key = t('info_panels.elevation.key');
+
+  return panel;
+}

--- a/modules/ui/panels/elevation.ts
+++ b/modules/ui/panels/elevation.ts
@@ -243,6 +243,7 @@ export function uiPanelElevation(context: iD.Context) {
         .append('div')
         .attr('class', 'elevation-loading')
         .call(t.append('info_panels.elevation.loading'));
+      drawAuxiliary.clear();
       return;
     }
 

--- a/modules/ui/panels/elevation.ts
+++ b/modules/ui/panels/elevation.ts
@@ -315,7 +315,20 @@ export function uiPanelElevation(context: iD.Context) {
     }
   }
 
+  function detachListeners() {
+    context.map().on('drawn.info-elevation', null);
+    context.on('enter.info-elevation', null);
+    context.history().on('change.info-elevation', null);
+    context.surface().on('pointermove.info-elevation', null);
+    elevation.on('profile.info-elevation', null);
+    elevation.on('hover.info-elevation', null);
+    context.background().on('change.info-elevation', null);
+  }
+
   const panel = function(selection: d3.Selection<any>) {
+    // uiInfo re-invokes active panels on every toggle; detach before re-attach.
+    detachListeners();
+
     elevation.setMapHoverEnabled(true);
     refreshProfile();
     selection.call(redraw);
@@ -354,13 +367,7 @@ export function uiPanelElevation(context: iD.Context) {
     elevation.setMapHoverEnabled(false);
     elevation.clearHover();
     drawAuxiliary.clear();
-    context.map().on('drawn.info-elevation', null);
-    context.on('enter.info-elevation', null);
-    context.history().on('change.info-elevation', null);
-    context.surface().on('pointermove.info-elevation', null);
-    elevation.on('profile.info-elevation', null);
-    elevation.on('hover.info-elevation', null);
-    context.background().on('change.info-elevation', null);
+    detachListeners();
   };
 
   panel.id = 'elevation';

--- a/modules/ui/panels/elevation.ts
+++ b/modules/ui/panels/elevation.ts
@@ -1,6 +1,5 @@
-import { t } from '../../core/localizer';
+import { t, localizer } from '../../core/localizer';
 import { displayLength } from '../../util/units';
-import { localizer } from '../../core/localizer';
 import { closestPointOnLine } from '../../elevation/geometry';
 import { profilePointAtDistance } from '../../elevation/profile';
 import type { ProfilePoint } from '../../elevation/profile';

--- a/modules/ui/panels/elevation.ts
+++ b/modules/ui/panels/elevation.ts
@@ -1,3 +1,5 @@
+import { select as d3_select } from 'd3-selection';
+
 import { t, localizer } from '../../core/localizer';
 import { displayLength } from '../../util/units';
 import { closestPointOnLine } from '../../elevation/geometry';
@@ -5,7 +7,7 @@ import { profilePointAtDistance } from '../../elevation/profile';
 import type { ProfilePoint } from '../../elevation/profile';
 import { svgElevationAuxiliary } from '../../svg/elevation_auxiliary';
 
-const CHART_WIDTH = 226;
+const CHART_WIDTH = 250;
 const CHART_HEIGHT = 90;
 const CHART_MARGIN = { top: 8, right: 8, bottom: 20, left: 36 };
 
@@ -80,7 +82,7 @@ export function uiPanelElevation(context: iD.Context) {
       return;
     }
 
-    const { minDist, maxDist, xScale, yScale, innerH } = scales;
+    const { minDist, maxDist, xScale, yScale } = scales;
     const valid = profile.filter(p => p.elevation !== null);
     const innerW = CHART_WIDTH - CHART_MARGIN.left - CHART_MARGIN.right;
     const points = valid.map(p => `${xScale(p.distance)},${yScale(p.elevation as number)}`).join(' ');
@@ -88,8 +90,10 @@ export function uiPanelElevation(context: iD.Context) {
     const chart = selection
       .append('svg')
       .attr('class', 'elevation-chart')
-      .attr('width', CHART_WIDTH)
-      .attr('height', CHART_HEIGHT);
+      .attr('width', '100%')
+      .attr('height', CHART_HEIGHT)
+      .attr('viewBox', `0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`)
+      .attr('preserveAspectRatio', 'none');
 
     chart
       .append('polyline')
@@ -100,15 +104,17 @@ export function uiPanelElevation(context: iD.Context) {
     chart
       .append('rect')
       .attr('class', 'elevation-chart-hit')
-      .attr('x', CHART_MARGIN.left)
-      .attr('y', CHART_MARGIN.top)
-      .attr('width', innerW)
-      .attr('height', innerH)
+      .attr('x', 0)
+      .attr('y', 0)
+      .attr('width', CHART_WIDTH)
+      .attr('height', CHART_HEIGHT)
       .attr('fill', 'transparent')
       .on('pointermove.elevation-chart', function(d3_event) {
         const rect = (this as SVGRectElement).getBoundingClientRect();
         const x = d3_event.clientX - rect.left;
-        const ratio = Math.max(0, Math.min(1, x / innerW));
+        const plotLeft = (CHART_MARGIN.left / CHART_WIDTH) * rect.width;
+        const plotWidth = (innerW / CHART_WIDTH) * rect.width;
+        const ratio = Math.max(0, Math.min(1, (x - plotLeft) / plotWidth));
         const distance = minDist + ratio * (maxDist - minDist);
         const point = profilePointAtDistance(profile, distance);
         if (point) {
@@ -174,29 +180,21 @@ export function uiPanelElevation(context: iD.Context) {
       .attr('y2', CHART_MARGIN.top + innerH);
   }
 
+  function hoverElevationText(elevationMeters: number): string {
+    return t('info_panels.elevation.at_point', {
+      elevation: Math.round(elevationMeters).toLocaleString(localizer.localeCode())
+    });
+  }
+
   function updateHover(selection: d3.Selection<any>) {
     const profile = elevation.profile();
     const hover = elevation.hover();
 
-    const current = selection.select('.elevation-current');
+    const current = selection.select('.elevation-chart-wrap .elevation-current');
     if (hover && hover.elevation !== null) {
-      const text = t('info_panels.elevation.at_point', {
-        elevation: Math.round(hover.elevation).toLocaleString(localizer.localeCode())
-      });
-      if (current.empty()) {
-        const chartWrap = selection.select('.elevation-chart-wrap');
-        if (chartWrap.empty()) {
-          selection.append('div').attr('class', 'elevation-current').text(text);
-        } else {
-          selection.insert('div', '.elevation-chart-wrap')
-            .attr('class', 'elevation-current')
-            .text(text);
-        }
-      } else {
-        current.text(text);
-      }
+      current.text(hoverElevationText(hover.elevation));
     } else {
-      current.remove();
+      current.text('');
     }
 
     updateChartCursor(selection.select('.elevation-chart'), profile, hover?.distance ?? null);
@@ -208,25 +206,50 @@ export function uiPanelElevation(context: iD.Context) {
     }
   }
 
+  function drawOverlayToggle(selection: d3.Selection<any>) {
+    const source = context.background().findSource(elevation.overlayId());
+    if (!source) return;
+
+    const overlayOn = context.background().showsLayer(source);
+
+    const item = selection
+      .append('ul')
+      .attr('class', 'layer-list elevation-overlay-toggle')
+      .append('li')
+      .classed('active', overlayOn);
+
+    const label = item.append('label');
+
+    label
+      .append('input')
+      .attr('type', 'checkbox')
+      .attr('name', 'layers')
+      .property('checked', overlayOn)
+      .on('change.elevation-panel', function(d3_event) {
+        d3_event.preventDefault();
+        context.background().toggleOverlayLayer(source);
+        const active = context.background().showsLayer(source);
+        d3_select(this).property('checked', active);
+        item.classed('active', active);
+        (document.activeElement as HTMLElement | null)?.blur();
+      });
+
+    label
+      .append('span')
+      .each(function() {
+        source.label()(d3_select(this));
+      });
+  }
+
   function redraw(selection: d3.Selection<any>) {
     const wayId = selectedWayId();
     const profile = elevation.profile();
     const hover = elevation.hover();
     const loading = elevation.profileLoading();
-    const overlayOn = elevation.showsOverlay();
 
     selection.html('');
 
-    selection
-      .append('button')
-      .attr('class', 'button elevation-layer-toggle')
-      .attr('type', 'button')
-      .text(t(overlayOn ? 'info_panels.elevation.hide_layer' : 'info_panels.elevation.show_layer'))
-      .on('click.elevation-panel', function(d3_event) {
-        d3_event.preventDefault();
-        elevation.toggleOverlay();
-        selection.call(redraw);
-      });
+    drawOverlayToggle(selection);
 
     if (!wayId) {
       selection
@@ -246,18 +269,14 @@ export function uiPanelElevation(context: iD.Context) {
       return;
     }
 
-    if (hover && hover.elevation !== null) {
-      selection
-        .append('div')
-        .attr('class', 'elevation-current')
-        .text(t('info_panels.elevation.at_point', {
-          elevation: Math.round(hover.elevation).toLocaleString(localizer.localeCode())
-        }));
-    }
-
     const chartContainer = selection
       .append('div')
       .attr('class', 'elevation-chart-wrap');
+
+    chartContainer
+      .append('div')
+      .attr('class', 'elevation-current')
+      .text(hover && hover.elevation !== null ? hoverElevationText(hover.elevation) : '');
 
     drawChart(chartContainer, profile, hover?.distance ?? null);
 
@@ -329,6 +348,7 @@ export function uiPanelElevation(context: iD.Context) {
     detachListeners();
 
     elevation.setMapHoverEnabled(true);
+    elevation.toggleOverlay(true);
     refreshProfile();
     selection.call(redraw);
 

--- a/modules/ui/panels/elevation.ts
+++ b/modules/ui/panels/elevation.ts
@@ -1,18 +1,52 @@
-import { select as d3_select } from 'd3-selection';
-
 import { t } from '../../core/localizer';
 import { displayLength } from '../../util/units';
 import { localizer } from '../../core/localizer';
 import { closestPointOnLine } from '../../elevation/geometry';
 import { profilePointAtDistance } from '../../elevation/profile';
+import type { ProfilePoint } from '../../elevation/profile';
 import { svgElevationAuxiliary } from '../../svg/elevation_auxiliary';
 
 const CHART_WIDTH = 226;
 const CHART_HEIGHT = 90;
 const CHART_MARGIN = { top: 8, right: 8, bottom: 20, left: 36 };
 
+interface ChartScales {
+  minDist: number;
+  maxDist: number;
+  xScale: (d: number) => number;
+  yScale: (e: number) => number;
+  innerH: number;
+}
+
+function chartScales(profile: ProfilePoint[]): ChartScales | null {
+  const valid = profile.filter(p => p.elevation !== null);
+  if (valid.length < 2) return null;
+
+  const distances = valid.map(p => p.distance);
+  const elevations = valid.map(p => p.elevation as number);
+  const minDist = distances[0];
+  const maxDist = distances[distances.length - 1];
+  const minEle = Math.min(...elevations);
+  const maxEle = Math.max(...elevations);
+  const elePad = Math.max(5, (maxEle - minEle) * 0.05);
+  const yMin = minEle - elePad;
+  const yMax = maxEle + elePad;
+
+  const innerW = CHART_WIDTH - CHART_MARGIN.left - CHART_MARGIN.right;
+  const innerH = CHART_HEIGHT - CHART_MARGIN.top - CHART_MARGIN.bottom;
+
+  return {
+    minDist,
+    maxDist,
+    innerH,
+    xScale: (d: number) => CHART_MARGIN.left + (d - minDist) / (maxDist - minDist || 1) * innerW,
+    yScale: (e: number) => CHART_MARGIN.top + innerH - (e - yMin) / (yMax - yMin || 1) * innerH
+  };
+}
+
 export function uiPanelElevation(context: iD.Context) {
   let _isImperial = !localizer.usesMetric();
+  let _wayNodeSignature: string | null = null;
   const elevation = context.elevation();
   const drawAuxiliary = svgElevationAuxiliary(context);
 
@@ -23,15 +57,23 @@ export function uiPanelElevation(context: iD.Context) {
     return entity.geometry(context.graph()) === 'line' ? ids[0] : null;
   }
 
+  function wayNodeSignature(wayId: EntityID): string {
+    const entity = context.entity(wayId);
+    return entity.nodes.map((id: EntityID) => {
+      const node = context.entity(id);
+      return `${id}:${node.loc[0].toFixed(7)},${node.loc[1].toFixed(7)}`;
+    }).join('|');
+  }
+
   function drawChart(
     selection: d3.Selection<any>,
-    profile: import('../../elevation/profile').ProfilePoint[],
+    profile: ProfilePoint[],
     hoverDistance: number | null
   ) {
     selection.selectAll('.elevation-chart').remove();
 
-    const valid = profile.filter(p => p.elevation !== null);
-    if (valid.length < 2) {
+    const scales = chartScales(profile);
+    if (!scales) {
       selection
         .append('div')
         .attr('class', 'elevation-chart-empty')
@@ -39,22 +81,9 @@ export function uiPanelElevation(context: iD.Context) {
       return;
     }
 
-    const distances = valid.map(p => p.distance);
-    const elevations = valid.map(p => p.elevation as number);
-    const minDist = distances[0];
-    const maxDist = distances[distances.length - 1];
-    const minEle = Math.min(...elevations);
-    const maxEle = Math.max(...elevations);
-    const elePad = Math.max(5, (maxEle - minEle) * 0.05);
-    const yMin = minEle - elePad;
-    const yMax = maxEle + elePad;
-
+    const { minDist, maxDist, xScale, yScale, innerH } = scales;
+    const valid = profile.filter(p => p.elevation !== null);
     const innerW = CHART_WIDTH - CHART_MARGIN.left - CHART_MARGIN.right;
-    const innerH = CHART_HEIGHT - CHART_MARGIN.top - CHART_MARGIN.bottom;
-
-    const xScale = (d: number) => CHART_MARGIN.left + (d - minDist) / (maxDist - minDist || 1) * innerW;
-    const yScale = (e: number) => CHART_MARGIN.top + innerH - (e - yMin) / (yMax - yMin || 1) * innerH;
-
     const points = valid.map(p => `${xScale(p.distance)},${yScale(p.elevation as number)}`).join(' ');
 
     const chart = selection
@@ -80,7 +109,7 @@ export function uiPanelElevation(context: iD.Context) {
       .on('pointermove.elevation-chart', function(d3_event) {
         const rect = (this as SVGRectElement).getBoundingClientRect();
         const x = d3_event.clientX - rect.left;
-        const ratio = Math.max(0, Math.min(1, (x - CHART_MARGIN.left) / innerW));
+        const ratio = Math.max(0, Math.min(1, x / innerW));
         const distance = minDist + ratio * (maxDist - minDist);
         const point = profilePointAtDistance(profile, distance);
         if (point) {
@@ -95,25 +124,7 @@ export function uiPanelElevation(context: iD.Context) {
         elevation.clearHover();
       });
 
-    if (hoverDistance !== null) {
-      const hoverPoint = profilePointAtDistance(profile, hoverDistance);
-      if (hoverPoint && hoverPoint.elevation !== null) {
-        chart
-          .append('circle')
-          .attr('class', 'elevation-chart-cursor')
-          .attr('cx', xScale(hoverPoint.distance))
-          .attr('cy', yScale(hoverPoint.elevation))
-          .attr('r', 4);
-
-        chart
-          .append('line')
-          .attr('class', 'elevation-chart-crosshair')
-          .attr('x1', xScale(hoverPoint.distance))
-          .attr('x2', xScale(hoverPoint.distance))
-          .attr('y1', CHART_MARGIN.top)
-          .attr('y2', CHART_MARGIN.top + innerH);
-      }
-    }
+    updateChartCursor(chart, profile, hoverDistance);
 
     chart
       .append('text')
@@ -131,6 +142,73 @@ export function uiPanelElevation(context: iD.Context) {
       .text(displayLength(maxDist, _isImperial));
   }
 
+  function updateChartCursor(
+    chart: d3.Selection<any>,
+    profile: ProfilePoint[],
+    hoverDistance: number | null
+  ) {
+    chart.selectAll('.elevation-chart-cursor, .elevation-chart-crosshair').remove();
+
+    if (hoverDistance === null) return;
+
+    const scales = chartScales(profile);
+    if (!scales) return;
+
+    const hoverPoint = profilePointAtDistance(profile, hoverDistance);
+    if (!hoverPoint || hoverPoint.elevation === null) return;
+
+    const { xScale, yScale, innerH } = scales;
+
+    chart
+      .append('circle')
+      .attr('class', 'elevation-chart-cursor')
+      .attr('cx', xScale(hoverPoint.distance))
+      .attr('cy', yScale(hoverPoint.elevation))
+      .attr('r', 4);
+
+    chart
+      .append('line')
+      .attr('class', 'elevation-chart-crosshair')
+      .attr('x1', xScale(hoverPoint.distance))
+      .attr('x2', xScale(hoverPoint.distance))
+      .attr('y1', CHART_MARGIN.top)
+      .attr('y2', CHART_MARGIN.top + innerH);
+  }
+
+  function updateHover(selection: d3.Selection<any>) {
+    const profile = elevation.profile();
+    const hover = elevation.hover();
+
+    const current = selection.select('.elevation-current');
+    if (hover && hover.elevation !== null) {
+      const text = t('info_panels.elevation.at_point', {
+        elevation: Math.round(hover.elevation).toLocaleString(localizer.localeCode())
+      });
+      if (current.empty()) {
+        const chartWrap = selection.select('.elevation-chart-wrap');
+        if (chartWrap.empty()) {
+          selection.append('div').attr('class', 'elevation-current').text(text);
+        } else {
+          selection.insert('div', '.elevation-chart-wrap')
+            .attr('class', 'elevation-current')
+            .text(text);
+        }
+      } else {
+        current.text(text);
+      }
+    } else {
+      current.remove();
+    }
+
+    updateChartCursor(selection.select('.elevation-chart'), profile, hover?.distance ?? null);
+
+    if (hover) {
+      drawAuxiliary.show(hover.loc);
+    } else {
+      drawAuxiliary.clear();
+    }
+  }
+
   function redraw(selection: d3.Selection<any>) {
     const wayId = selectedWayId();
     const profile = elevation.profile();
@@ -140,7 +218,7 @@ export function uiPanelElevation(context: iD.Context) {
 
     selection.html('');
 
-    const layerToggle = selection
+    selection
       .append('button')
       .attr('class', 'button elevation-layer-toggle')
       .attr('type', 'button')
@@ -150,9 +228,6 @@ export function uiPanelElevation(context: iD.Context) {
         elevation.toggleOverlay();
         selection.call(redraw);
       });
-
-    layerToggle
-      .append('span');
 
     if (!wayId) {
       selection
@@ -196,8 +271,10 @@ export function uiPanelElevation(context: iD.Context) {
   function refreshProfile() {
     const wayId = selectedWayId();
     if (wayId) {
+      _wayNodeSignature = wayNodeSignature(wayId);
       elevation.loadProfileForWay(wayId);
     } else {
+      _wayNodeSignature = null;
       elevation.clearProfile();
     }
   }
@@ -230,14 +307,20 @@ export function uiPanelElevation(context: iD.Context) {
     }
   }
 
+  function onMapDrawn() {
+    const hover = elevation.hover();
+    if (hover) {
+      drawAuxiliary.show(hover.loc);
+    }
+  }
+
   const panel = function(selection: d3.Selection<any>) {
     elevation.setMapHoverEnabled(true);
     refreshProfile();
     selection.call(redraw);
 
     context.map()
-      .on('drawn.info-elevation', () => selection.call(redraw))
-      .on('move.info-elevation', onMapPointerMove);
+      .on('drawn.info-elevation', onMapDrawn);
 
     context
       .on('enter.info-elevation', () => {
@@ -248,7 +331,10 @@ export function uiPanelElevation(context: iD.Context) {
     context.history()
       .on('change.info-elevation', () => {
         const wayId = selectedWayId();
-        if (wayId) {
+        if (!wayId) return;
+        const sig = wayNodeSignature(wayId);
+        if (sig !== _wayNodeSignature) {
+          _wayNodeSignature = sig;
           elevation.loadProfileForWay(wayId, { force: true });
         }
       });
@@ -257,7 +343,7 @@ export function uiPanelElevation(context: iD.Context) {
       .on('pointermove.info-elevation', onMapPointerMove);
 
     elevation.on('profile.info-elevation', () => selection.call(redraw));
-    elevation.on('hover.info-elevation', () => selection.call(redraw));
+    elevation.on('hover.info-elevation', () => selection.call(updateHover));
 
     context.background()
       .on('change.info-elevation', () => selection.call(redraw));
@@ -267,7 +353,7 @@ export function uiPanelElevation(context: iD.Context) {
     elevation.setMapHoverEnabled(false);
     elevation.clearHover();
     drawAuxiliary.clear();
-    context.map().on('drawn.info-elevation', null).on('move.info-elevation', null);
+    context.map().on('drawn.info-elevation', null);
     context.on('enter.info-elevation', null);
     context.history().on('change.info-elevation', null);
     context.surface().on('pointermove.info-elevation', null);

--- a/modules/ui/panels/index.js
+++ b/modules/ui/panels/index.js
@@ -2,15 +2,18 @@ export * from './background';
 export * from './history';
 export * from './location';
 export * from './measurement';
+export * from './elevation';
 
 import { uiPanelBackground } from './background';
 import { uiPanelHistory } from './history';
 import { uiPanelLocation } from './location';
 import { uiPanelMeasurement } from './measurement';
+import { uiPanelElevation } from './elevation';
 
 export var uiInfoPanels = {
     background: uiPanelBackground,
     history: uiPanelHistory,
     location: uiPanelLocation,
     measurement: uiPanelMeasurement,
+    elevation: uiPanelElevation,
 };

--- a/modules/ui/sections/background_list.js
+++ b/modules/ui/sections/background_list.js
@@ -114,6 +114,29 @@ export function uiSectionBackgroundList(context) {
             .call(t.append('background.location_panel.description'));
 
 
+        var elevationPanelLabelEnter = bgExtrasListEnter
+            .append('li')
+            .attr('class', 'elevation-panel-toggle-item')
+            .append('label')
+            .call(uiTooltip()
+                .title(() => t.append('background.elevation_panel.tooltip'))
+                .keys([uiCmd('⌘⇧' + t('info_panels.elevation.key'))])
+                .placement('top')
+            );
+
+        elevationPanelLabelEnter
+            .append('input')
+            .attr('type', 'checkbox')
+            .on('change', function(d3_event) {
+                d3_event.preventDefault();
+                context.ui().info.toggle('elevation');
+            });
+
+        elevationPanelLabelEnter
+            .append('span')
+            .call(t.append('background.elevation_panel.description'));
+
+
         // "Info / Report a Problem" link
         selection.selectAll('.imagery-faq')
             .data([0])

--- a/scripts/update_imagery.js
+++ b/scripts/update_imagery.js
@@ -86,7 +86,7 @@ sources.features.forEach(feature => {
   const source = feature.properties;
 
   if (!source) return;
-  if (source.type !== 'tms' && source.type !== 'wms' && source.type !== 'bing') return;
+  if (source.type !== 'tms' && source.type !== 'wms' && source.type !== 'bing' && source.type !== 'dem') return;
   if (discard.some(regex => regex.test(source.id))) return;
 
   let im = {
@@ -174,7 +174,7 @@ sources.features.forEach(feature => {
     im.terms_html = attribution.html;
   }
 
-  ['best', 'default', 'description', 'encrypted', 'icon', 'overlay', 'tileSize'].forEach(prop => {
+  ['best', 'default', 'description', 'encrypted', 'encoding', 'icon', 'overlay', 'tileSize'].forEach(prop => {
     if (source[prop]) {
       im[prop] = source[prop];
     }

--- a/test/spec/elevation/manager.js
+++ b/test/spec/elevation/manager.js
@@ -1,0 +1,52 @@
+import { vi } from 'vitest';
+import * as profile from '../../../modules/elevation/profile';
+import { elevationManager } from '../../../modules/elevation/manager';
+
+describe('elevation manager', function() {
+  let context;
+  let manager;
+  let way;
+
+  beforeEach(function() {
+    context = iD.coreContext().assetPath('../dist/').init();
+    manager = elevationManager(context);
+
+    const n1 = new iD.osmNode({ id: 'n1', loc: [0, 0] });
+    const n2 = new iD.osmNode({ id: 'n2', loc: [0, 0.01] });
+    way = new iD.osmWay({ id: 'w1', nodes: ['n1', 'n2'] });
+    context.history().merge([n1, n2, way]);
+
+    vi.restoreAllMocks();
+  });
+
+  it('ignores stale profile completions when switching ways quickly', async function() {
+    let resolveFirst;
+    let resolveSecond;
+    const firstPromise = new Promise(resolve => { resolveFirst = resolve; });
+    const secondPromise = new Promise(resolve => { resolveSecond = resolve; });
+
+    vi.spyOn(profile, 'buildElevationProfile')
+      .mockReturnValueOnce(firstPromise)
+      .mockReturnValueOnce(secondPromise);
+
+    const n3 = new iD.osmNode({ id: 'n3', loc: [1, 0] });
+    const n4 = new iD.osmNode({ id: 'n4', loc: [1, 0.01] });
+    const way2 = new iD.osmWay({ id: 'w2', nodes: ['n3', 'n4'] });
+    context.history().merge([n3, n4, way2]);
+
+    const load1 = manager.loadProfileForWay('w1');
+    const load2 = manager.loadProfileForWay('w2');
+
+    resolveSecond([{ loc: [1, 0.01], distance: 100, elevation: 50 }]);
+    await load2;
+
+    expect(manager.profileWayId()).to.eql('w2');
+    expect(manager.profile()).to.eql([{ loc: [1, 0.01], distance: 100, elevation: 50 }]);
+
+    resolveFirst([{ loc: [0, 0.01], distance: 100, elevation: 10 }]);
+    await load1;
+
+    expect(manager.profileWayId()).to.eql('w2');
+    expect(manager.profile()).to.eql([{ loc: [1, 0.01], distance: 100, elevation: 50 }]);
+  });
+});

--- a/test/spec/elevation/profile.js
+++ b/test/spec/elevation/profile.js
@@ -1,0 +1,56 @@
+import { densifyLine, profilePointAtDistance } from '../../../modules/elevation/profile';
+
+describe('elevation profile', function() {
+  describe('densifyLine', function() {
+    it('returns single point for one coordinate', function() {
+      const result = densifyLine([[0, 0]]);
+      expect(result).to.eql([{ loc: [0, 0], distance: 0 }]);
+    });
+
+    it('spaces samples along a segment', function() {
+      const coords = [[0, 0], [0, 0.001]];
+      const result = densifyLine(coords, 50);
+      expect(result.length).to.be.greaterThan(1);
+      expect(result[0]).to.eql({ loc: [0, 0], distance: 0 });
+      expect(result[result.length - 1].loc[0]).to.eql(0);
+      expect(result[result.length - 1].loc[1]).to.eql(0.001);
+      expect(result[result.length - 1].distance).to.be.greaterThan(0);
+    });
+
+    it('accumulates distance across multiple segments', function() {
+      const coords = [[0, 0], [0, 0.001], [0, 0.002]];
+      const result = densifyLine(coords, 100);
+      const last = result[result.length - 1];
+      expect(last.loc).to.eql([0, 0.002]);
+      expect(last.distance).to.be.greaterThan(result[1].distance);
+    });
+  });
+
+  describe('profilePointAtDistance', function() {
+    const profile = [
+      { loc: [0, 0], distance: 0, elevation: 100 },
+      { loc: [0, 1], distance: 100, elevation: 200 },
+      { loc: [0, 2], distance: 200, elevation: 300 }
+    ];
+
+    it('returns first point at or before start', function() {
+      expect(profilePointAtDistance(profile, -10)).to.eql(profile[0]);
+      expect(profilePointAtDistance(profile, 0)).to.eql(profile[0]);
+    });
+
+    it('returns last point beyond end', function() {
+      expect(profilePointAtDistance(profile, 500)).to.eql(profile[2]);
+    });
+
+    it('interpolates between points', function() {
+      const mid = profilePointAtDistance(profile, 50);
+      expect(mid.distance).to.eql(50);
+      expect(mid.loc).to.eql([0, 0.5]);
+      expect(mid.elevation).to.eql(150);
+    });
+
+    it('returns null for empty profile', function() {
+      expect(profilePointAtDistance([], 10)).to.be.null;
+    });
+  });
+});

--- a/test/spec/elevation/terrarium.js
+++ b/test/spec/elevation/terrarium.js
@@ -1,0 +1,23 @@
+import { terrariumToElevation } from '../../../modules/elevation/terrarium';
+
+describe('elevation terrarium', function() {
+  describe('terrariumToElevation', function() {
+    it('decodes sea level as zero', function() {
+      // (128 * 256 + 0 + 0 / 256) - 32768 = 0
+      expect(terrariumToElevation(128, 0, 0)).to.eql(0);
+    });
+
+    it('decodes positive elevation', function() {
+      expect(terrariumToElevation(130, 0, 0)).to.eql(512);
+    });
+
+    it('decodes negative elevation', function() {
+      expect(terrariumToElevation(126, 0, 0)).to.eql(-512);
+    });
+
+    it('uses green and blue channels for sub-meter precision', function() {
+      expect(terrariumToElevation(128, 1, 0)).to.eql(1);
+      expect(terrariumToElevation(128, 0, 256)).to.eql(1);
+    });
+  });
+});

--- a/test/spec/elevation/tile_cache.js
+++ b/test/spec/elevation/tile_cache.js
@@ -1,0 +1,26 @@
+import { DemTileCache } from '../../../modules/elevation/tile_cache';
+
+describe('DemTileCache', function() {
+  it('retries after a failed fetch instead of caching null forever', async function() {
+    const cache = new DemTileCache(10);
+    let calls = 0;
+    const originalFetch = globalThis.fetch;
+
+    globalThis.fetch = async function() {
+      calls++;
+      return { ok: false };
+    };
+
+    try {
+      const first = await cache.fetch('https://example.test/0/0/0.webp', 0, 0, 0, 1);
+      expect(first).to.eql(null);
+      expect(calls).to.eql(1);
+
+      const second = await cache.fetch('https://example.test/0/0/0.webp', 0, 0, 0, 1);
+      expect(second).to.eql(null);
+      expect(calls).to.eql(2);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/test/spec/elevation/tile_cache.js
+++ b/test/spec/elevation/tile_cache.js
@@ -6,9 +6,9 @@ describe('DemTileCache', function() {
     let calls = 0;
     const originalFetch = globalThis.fetch;
 
-    globalThis.fetch = async function() {
+    globalThis.fetch = function() {
       calls++;
-      return { ok: false };
+      return Promise.resolve({ ok: false });
     };
 
     try {
@@ -20,6 +20,7 @@ describe('DemTileCache', function() {
       expect(second).to.eql(null);
       expect(calls).to.eql(2);
     } finally {
+      // eslint-disable-next-line require-atomic-updates -- restore stub after awaits
       globalThis.fetch = originalFetch;
     }
   });


### PR DESCRIPTION
## Testing

* https://deploy-preview-3--tordans-id-experiments.netlify.app/#disable_features=boundaries&map=16.82/48.09233/9.10594&background=Bing&locale=en&overlays=mapterhorn-hillshade&id=w41804437
* https://deploy-preview-3--tordans-id-experiments.netlify.app/#disable_features=boundaries&map=17.57/47.59381/11.30935&background=Bing&locale=en&overlays=mapterhorn-hillshade&id=w45271525

Thanks to https://mapterhorn.com/examples/terrain/

Note to self: Edit redirect URL at https://www.openstreetmap.org/oauth2/applications/12061/edit

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Elevation readout** — Moved to bottom-left of the chart with absolute positioning so it no longer affects panel height.
- **Chart interaction** — Hover now works across the full graph height; chart spans the full panel width with a light border.
- **Overlay toggle** — Replaced Show/Hide Layer button with the same checkbox + label used in Background → Overlays (`mapterhorn-hillshade`), wired to the existing `overlays=` URL param. Hillshade defaults on when the panel opens.

## Test plan

- [ ] Open elevation panel — hillshade overlay checkbox is checked and layer is visible
- [ ] Uncheck overlay — hillshade turns off and URL `overlays=` updates
- [ ] Select a line — profile renders full width with border
- [ ] Hover anywhere on chart height — elevation readout and map marker update
- [ ] Elevation text stays at bottom-left without shifting panel layout
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fb7d3-1823-71aa-870d-ea3dfa73926a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fb7d3-1823-71aa-870d-ea3dfa73926a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



## Screenshots

* <img width="402" height="404" alt="image" src="https://github.com/user-attachments/assets/5f90ae5d-0336-4633-86d9-c934ba72a1c4" />
* <img width="528" height="419" alt="image" src="https://github.com/user-attachments/assets/68d13d58-299c-4ff5-8e42-dd72a9ce609e" />
* With Background:None
   <img width="476" height="411" alt="image" src="https://github.com/user-attachments/assets/7a5c4def-212c-4902-a392-e1d473fc8e40" />

